### PR TITLE
fix: radio-proto consensus sim finality progression

### DIFF
--- a/crates/bunkerglow/src/consensus/pool.rs
+++ b/crates/bunkerglow/src/consensus/pool.rs
@@ -280,6 +280,12 @@ impl PoolImpl {
             Cert::FastFinal(_) => {
                 info!("fast finalized slot {slot}");
                 self.highest_finalized_slot = slot.max(self.highest_finalized_slot);
+                if let Some(hash) = cert.block_hash() {
+                    let finalization_event = self
+                        .finality_tracker
+                        .mark_fast_finalized(slot, hash.clone());
+                    self.handle_finalization(finalization_event).await;
+                }
 
                 if let Some(ref blockstore) = self.blockstore {
                     if let Some(hash) = cert.block_hash() {
@@ -299,6 +305,8 @@ impl PoolImpl {
             Cert::Final(_) => {
                 info!("slow finalized slot {slot}");
                 self.highest_finalized_slot = slot.max(self.highest_finalized_slot);
+                let finalization_event = self.finality_tracker.mark_finalized(slot);
+                self.handle_finalization(finalization_event).await;
 
                 if let Some(ref blockstore) = self.blockstore {
                     if let Some(state) = self.slot_states.get(&slot) {

--- a/crates/sim/src/scenarios.rs
+++ b/crates/sim/src/scenarios.rs
@@ -264,12 +264,18 @@ pub async fn multi_node_consensus_simulation(num_nodes: usize) {
     for (i, v) in validators.iter().enumerate() {
         let epoch_info = Arc::new(EpochInfo::new(0, v.id, validators.clone()));
         let a2a_net: SimulatedNetwork<ConsensusMessage, ConsensusMessage> =
-            a2a_core.join_unlimited(i as u64).await;
-        let dis_net: SimulatedNetwork<Shred, Shred> = dis_core.join_unlimited(i as u64).await;
+            a2a_core.join_unlimited(v.all2all_address.port() as u64).await;
+        let dis_net: SimulatedNetwork<Shred, Shred> = dis_core
+            .join_unlimited(v.disseminator_address.port() as u64)
+            .await;
         let rep_net: SimulatedNetwork<RepairRequest, RepairResponse> =
-            rep_core.join_unlimited(i as u64).await;
+            rep_core
+                .join_unlimited(v.repair_response_address.port() as u64)
+                .await;
         let rep_req_net: SimulatedNetwork<RepairResponse, RepairRequest> =
-            rep_req_core.join_unlimited(i as u64).await;
+            rep_req_core
+                .join_unlimited(v.repair_request_address.port() as u64)
+                .await;
         let txs_net: SimulatedNetwork<Transaction, Transaction> =
             txs_core.join_unlimited(i as u64).await;
         let all2all = TrivialAll2All::new(validators.clone(), a2a_net);
@@ -297,10 +303,8 @@ pub async fn multi_node_consensus_simulation(num_nodes: usize) {
         tokio::spawn(async move {
             loop {
                 tokio::time::sleep(Duration::from_secs(2)).await;
-                for (i, pool, blockstore) in &pools_and_blockstores {
-                    let finalized = pool.read().await.finalized_slot();
+                for (_i, pool, _blockstore) in &pools_and_blockstores {
                     pool.write().await.prune_old_slots();
-                    blockstore.write().await.clean_beyond_finalized(finalized);
                     let pool_guard = pool.read().await;
                     println!("pool slot_states: {}", pool_guard.slot_states_len());
                 }
@@ -390,12 +394,18 @@ pub async fn multi_node_consensus_simulation_with_api(
     for (i, v) in validators.iter().enumerate() {
         let epoch_info = Arc::new(EpochInfo::new(0, v.id, validators.clone()));
         let a2a_net: SimulatedNetwork<ConsensusMessage, ConsensusMessage> =
-            a2a_core.join_unlimited(i as u64).await;
-        let dis_net: SimulatedNetwork<Shred, Shred> = dis_core.join_unlimited(i as u64).await;
+            a2a_core.join_unlimited(v.all2all_address.port() as u64).await;
+        let dis_net: SimulatedNetwork<Shred, Shred> = dis_core
+            .join_unlimited(v.disseminator_address.port() as u64)
+            .await;
         let rep_net: SimulatedNetwork<RepairRequest, RepairResponse> =
-            rep_core.join_unlimited(i as u64).await;
+            rep_core
+                .join_unlimited(v.repair_response_address.port() as u64)
+                .await;
         let rep_req_net: SimulatedNetwork<RepairResponse, RepairRequest> =
-            rep_req_core.join_unlimited(i as u64).await;
+            rep_req_core
+                .join_unlimited(v.repair_request_address.port() as u64)
+                .await;
         let txs_net: SimulatedNetwork<Transaction, Transaction> =
             txs_core.join_unlimited(i as u64).await;
         let all2all = TrivialAll2All::new(validators.clone(), a2a_net);
@@ -808,10 +818,8 @@ pub async fn multi_node_consensus_simulation_with_api(
                     last_executed_slot = consensus_finalized_slot;
                 }
 
-                for (_i, pool, blockstore) in &pools_and_blockstores {
-                    let finalized = pool.read().await.finalized_slot();
+                for (_i, pool, _blockstore) in &pools_and_blockstores {
                     pool.write().await.prune_old_slots();
-                    blockstore.write().await.clean_beyond_finalized(finalized);
                     let pool_guard = pool.read().await;
                     println!("Pool slot_states: {}", pool_guard.slot_states_len());
                 }

--- a/crates/sim/src/scenarios.rs
+++ b/crates/sim/src/scenarios.rs
@@ -263,19 +263,18 @@ pub async fn multi_node_consensus_simulation(num_nodes: usize) {
     let mut nodes_with_id = Vec::new();
     for (i, v) in validators.iter().enumerate() {
         let epoch_info = Arc::new(EpochInfo::new(0, v.id, validators.clone()));
-        let a2a_net: SimulatedNetwork<ConsensusMessage, ConsensusMessage> =
-            a2a_core.join_unlimited(v.all2all_address.port() as u64).await;
+        let a2a_net: SimulatedNetwork<ConsensusMessage, ConsensusMessage> = a2a_core
+            .join_unlimited(v.all2all_address.port() as u64)
+            .await;
         let dis_net: SimulatedNetwork<Shred, Shred> = dis_core
             .join_unlimited(v.disseminator_address.port() as u64)
             .await;
-        let rep_net: SimulatedNetwork<RepairRequest, RepairResponse> =
-            rep_core
-                .join_unlimited(v.repair_response_address.port() as u64)
-                .await;
-        let rep_req_net: SimulatedNetwork<RepairResponse, RepairRequest> =
-            rep_req_core
-                .join_unlimited(v.repair_request_address.port() as u64)
-                .await;
+        let rep_net: SimulatedNetwork<RepairRequest, RepairResponse> = rep_core
+            .join_unlimited(v.repair_response_address.port() as u64)
+            .await;
+        let rep_req_net: SimulatedNetwork<RepairResponse, RepairRequest> = rep_req_core
+            .join_unlimited(v.repair_request_address.port() as u64)
+            .await;
         let txs_net: SimulatedNetwork<Transaction, Transaction> =
             txs_core.join_unlimited(i as u64).await;
         let all2all = TrivialAll2All::new(validators.clone(), a2a_net);
@@ -393,19 +392,18 @@ pub async fn multi_node_consensus_simulation_with_api(
     let mut nodes_with_id = Vec::new();
     for (i, v) in validators.iter().enumerate() {
         let epoch_info = Arc::new(EpochInfo::new(0, v.id, validators.clone()));
-        let a2a_net: SimulatedNetwork<ConsensusMessage, ConsensusMessage> =
-            a2a_core.join_unlimited(v.all2all_address.port() as u64).await;
+        let a2a_net: SimulatedNetwork<ConsensusMessage, ConsensusMessage> = a2a_core
+            .join_unlimited(v.all2all_address.port() as u64)
+            .await;
         let dis_net: SimulatedNetwork<Shred, Shred> = dis_core
             .join_unlimited(v.disseminator_address.port() as u64)
             .await;
-        let rep_net: SimulatedNetwork<RepairRequest, RepairResponse> =
-            rep_core
-                .join_unlimited(v.repair_response_address.port() as u64)
-                .await;
-        let rep_req_net: SimulatedNetwork<RepairResponse, RepairRequest> =
-            rep_req_core
-                .join_unlimited(v.repair_request_address.port() as u64)
-                .await;
+        let rep_net: SimulatedNetwork<RepairRequest, RepairResponse> = rep_core
+            .join_unlimited(v.repair_response_address.port() as u64)
+            .await;
+        let rep_req_net: SimulatedNetwork<RepairResponse, RepairRequest> = rep_req_core
+            .join_unlimited(v.repair_request_address.port() as u64)
+            .await;
         let txs_net: SimulatedNetwork<Transaction, Transaction> =
             txs_core.join_unlimited(i as u64).await;
         let all2all = TrivialAll2All::new(validators.clone(), a2a_net);


### PR DESCRIPTION
## Summary

  Fixes the radio-proto multi-node consensus simulation getting stuck at finalized slot 0.

  The simulated radio network was registering nodes with local indexes, while message routing uses validator address ports as node IDs. This caused consensus messages to miss their intended recipients. The pool also accepted finalization certificates without updating the finality tracker used by `finalized_slot()`.

  ## Changes

  - Register simulated network peers by validator address port.
  - Update the finality tracker when fast and slow final certificates are added to the pool.
  - Stop pruning blockstore state on every simulation monitoring tick.