### PR TITLE
feat: pactor transport foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3243,9 +3243,11 @@ name = "scs_pactor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bytes",
  "futures-util",
  "log",
+ "rand 0.9.1",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/crates/scs_pactor/Cargo.toml
+++ b/crates/scs_pactor/Cargo.toml
@@ -10,8 +10,9 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 log = { workspace = true }
+rand = { workspace = true }
 bytes = "1"
 tokio-util = { version = "0.7", features = ["codec"] }
 futures-util = { version = "0.3", features = ["sink"] }
-
+async-trait = "0.1"
 

--- a/crates/scs_pactor/src/hostmode.rs
+++ b/crates/scs_pactor/src/hostmode.rs
@@ -1,0 +1,169 @@
+use crate::ScsPactorError;
+
+const FRAME_START: u8 = 0xAA;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostmodeFrame {
+    pub channel: u8,
+    pub payload: Vec<u8>,
+}
+
+impl HostmodeFrame {
+    pub fn new(channel: u8, payload: impl Into<Vec<u8>>) -> Self {
+        Self {
+            channel,
+            payload: payload.into(),
+        }
+    }
+}
+
+pub fn encode_frame(frame: &HostmodeFrame) -> Result<Vec<u8>, ScsPactorError> {
+    if frame.payload.len() > u16::MAX as usize {
+        return Err(ScsPactorError::ExceedsMtu(frame.payload.len()));
+    }
+
+    let len = frame.payload.len() as u16;
+    let mut encoded = Vec::with_capacity(frame.payload.len() + 6);
+    encoded.push(FRAME_START);
+    encoded.push(frame.channel);
+    encoded.extend_from_slice(&len.to_be_bytes());
+    encoded.extend_from_slice(&frame.payload);
+
+    let crc = crc16_ccitt_false(&encoded[1..]);
+    encoded.extend_from_slice(&crc.to_be_bytes());
+    Ok(encoded)
+}
+
+pub fn decode_frame(bytes: &[u8]) -> Result<HostmodeFrame, ScsPactorError> {
+    if bytes.len() < 6 {
+        return Err(ScsPactorError::Protocol(
+            "hostmode frame too short".to_owned(),
+        ));
+    }
+    if bytes[0] != FRAME_START {
+        return Err(ScsPactorError::Protocol(
+            "hostmode frame start missing".to_owned(),
+        ));
+    }
+
+    let channel = bytes[1];
+    let len = u16::from_be_bytes([bytes[2], bytes[3]]) as usize;
+    let expected_len = 1 + 1 + 2 + len + 2;
+    if bytes.len() != expected_len {
+        return Err(ScsPactorError::Protocol(format!(
+            "hostmode frame length mismatch: expected {expected_len}, got {}",
+            bytes.len()
+        )));
+    }
+
+    let crc_offset = bytes.len() - 2;
+    let expected_crc = u16::from_be_bytes([bytes[crc_offset], bytes[crc_offset + 1]]);
+    let actual_crc = crc16_ccitt_false(&bytes[1..crc_offset]);
+    if actual_crc != expected_crc {
+        return Err(ScsPactorError::Protocol(
+            "hostmode frame crc mismatch".to_owned(),
+        ));
+    }
+
+    Ok(HostmodeFrame {
+        channel,
+        payload: bytes[4..crc_offset].to_vec(),
+    })
+}
+
+#[derive(Debug, Default)]
+pub struct HostmodeDecoder {
+    buffer: Vec<u8>,
+}
+
+impl HostmodeDecoder {
+    pub fn new() -> Self {
+        Self { buffer: Vec::new() }
+    }
+
+    pub fn push(&mut self, bytes: &[u8]) {
+        self.buffer.extend_from_slice(bytes);
+    }
+
+    pub fn next_frame(&mut self) -> Result<Option<HostmodeFrame>, ScsPactorError> {
+        let Some(start) = self.buffer.iter().position(|byte| *byte == FRAME_START) else {
+            self.buffer.clear();
+            return Ok(None);
+        };
+        if start > 0 {
+            self.buffer.drain(..start);
+        }
+
+        if self.buffer.len() < 4 {
+            return Ok(None);
+        }
+
+        let payload_len = u16::from_be_bytes([self.buffer[2], self.buffer[3]]) as usize;
+        let frame_len = 1 + 1 + 2 + payload_len + 2;
+        if self.buffer.len() < frame_len {
+            return Ok(None);
+        }
+
+        let frame_bytes: Vec<u8> = self.buffer.drain(..frame_len).collect();
+        decode_frame(&frame_bytes).map(Some)
+    }
+}
+
+fn crc16_ccitt_false(bytes: &[u8]) -> u16 {
+    let mut crc = 0xFFFFu16;
+    for byte in bytes {
+        crc ^= (*byte as u16) << 8;
+        for _ in 0..8 {
+            if crc & 0x8000 != 0 {
+                crc = (crc << 1) ^ 0x1021;
+            } else {
+                crc <<= 1;
+            }
+        }
+    }
+    crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hostmode_frame_round_trip() {
+        let frame = HostmodeFrame::new(1, b"MYCALL N0CALL".to_vec());
+        let encoded = encode_frame(&frame).unwrap();
+        let decoded = decode_frame(&encoded).unwrap();
+        assert_eq!(decoded, frame);
+    }
+
+    #[test]
+    fn hostmode_frame_rejects_bad_crc() {
+        let frame = HostmodeFrame::new(2, b"payload".to_vec());
+        let mut encoded = encode_frame(&frame).unwrap();
+        let last = encoded.len() - 1;
+        encoded[last] ^= 0x01;
+        let err = decode_frame(&encoded).unwrap_err();
+        assert!(matches!(err, ScsPactorError::Protocol(_)));
+    }
+
+    #[test]
+    fn decoder_resyncs_after_garbage() {
+        let frame = HostmodeFrame::new(7, b"D".to_vec());
+        let encoded = encode_frame(&frame).unwrap();
+
+        let mut decoder = HostmodeDecoder::new();
+        decoder.push(&[0x00, 0x01, 0x02, 0x03]);
+        assert_eq!(decoder.next_frame().unwrap(), None);
+
+        decoder.push(&encoded[..3]);
+        assert_eq!(decoder.next_frame().unwrap(), None);
+
+        decoder.push(&encoded[3..]);
+        assert_eq!(decoder.next_frame().unwrap(), Some(frame));
+    }
+
+    #[test]
+    fn crc_known_vector() {
+        assert_eq!(crc16_ccitt_false(b"123456789"), 0x29B1);
+    }
+}

--- a/crates/scs_pactor/src/lib.rs
+++ b/crates/scs_pactor/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod hostmode;
 pub mod simulator;
 pub mod tcp;
+pub mod usb;
 
 use std::time::Duration;
 
@@ -11,6 +12,7 @@ pub use simulator::{
     PactorSpeed, SimulatedPactorConfig, SimulatedPactorPair, SimulatedPactorTransport,
 };
 pub use tcp::{ScsPactorClient, ScsPactorConfig};
+pub use usb::{UsbPactorConfig, UsbPactorTransport};
 
 #[derive(Debug, Error)]
 pub enum ScsPactorError {

--- a/crates/scs_pactor/src/lib.rs
+++ b/crates/scs_pactor/src/lib.rs
@@ -1,13 +1,16 @@
-use std::net::SocketAddr;
+pub mod hostmode;
+pub mod simulator;
+pub mod tcp;
+
 use std::time::Duration;
 
-use futures_util::{SinkExt, StreamExt};
+use async_trait::async_trait;
 use thiserror::Error;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{lookup_host, TcpStream};
-use tokio::sync::Mutex;
-use tokio::time::timeout;
-use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec};
+
+pub use simulator::{
+    PactorSpeed, SimulatedPactorConfig, SimulatedPactorPair, SimulatedPactorTransport,
+};
+pub use tcp::{ScsPactorClient, ScsPactorConfig};
 
 #[derive(Debug, Error)]
 pub enum ScsPactorError {
@@ -25,162 +28,40 @@ pub enum ScsPactorError {
 
     #[error("disconnected from peer")]
     Disconnected,
+
+    #[error("modem is busy")]
+    Busy,
+
+    #[error("protocol error: {0}")]
+    Protocol(String),
 }
 
-#[derive(Clone, Debug)]
-pub struct ScsPactorConfig {
-    pub addr: SocketAddr,
-    pub read_timeout: Option<Duration>,
-    pub write_timeout: Option<Duration>,
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PactorLinkStatus {
+    Idle,
+    Connecting { remote_call: String },
+    Connected { remote_call: String },
+    Disconnected,
+    LinkFailure,
+    Busy,
 }
 
-impl ScsPactorConfig {
-    pub async fn resolve(host: &str, port: u16) -> Result<Self, ScsPactorError> {
-        let mut addrs = lookup_host((host, port)).await?;
-        let addr = addrs.next().ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::AddrNotAvailable, "no addresses")
-        })?;
-        Ok(Self {
-            addr,
-            read_timeout: Some(Duration::from_secs(10)),
-            write_timeout: Some(Duration::from_secs(10)),
-        })
-    }
+#[derive(Clone, Debug, PartialEq)]
+pub enum PactorLinkEvent {
+    Status(PactorLinkStatus),
+    LinkQuality { speed_level: u8, retries: u32 },
 }
 
-pub struct ScsPactorClient {
-    cmd_writer: Mutex<FramedWrite<tokio::net::tcp::OwnedWriteHalf, LinesCodec>>,
-    cmd_reader: Mutex<FramedRead<tokio::net::tcp::OwnedReadHalf, LinesCodec>>,
-    data_writer: Mutex<tokio::net::tcp::OwnedWriteHalf>,
-    data_reader: Mutex<tokio::net::tcp::OwnedReadHalf>,
-    read_timeout: Option<Duration>,
-    write_timeout: Option<Duration>,
-    peer_addr: SocketAddr,
-}
+#[async_trait]
+pub trait PactorTransport: Send + Sync {
+    async fn set_mycall(&self, callsign: &str) -> Result<(), ScsPactorError>;
+    async fn connect_peer(&self, remote_call: &str) -> Result<(), ScsPactorError>;
+    async fn write_data(&self, data: &[u8]) -> Result<(), ScsPactorError>;
+    async fn read_data(&self, max_len: usize) -> Result<Vec<u8>, ScsPactorError>;
+    async fn disconnect(&self) -> Result<(), ScsPactorError>;
 
-impl ScsPactorClient {
-    pub async fn connect(config: ScsPactorConfig) -> Result<Self, ScsPactorError> {
-        let stream = TcpStream::connect(config.addr).await?;
-        stream.set_nodelay(true)?;
-        let peer_addr = stream.peer_addr()?;
-
-        let (r, w) = stream.into_split();
-        let cmd_reader = FramedRead::new(r, LinesCodec::new());
-        let cmd_writer = FramedWrite::new(w, LinesCodec::new());
-
-        let stream2 = TcpStream::connect(peer_addr).await?;
-        stream2.set_nodelay(true)?;
-        let (r2, w2) = stream2.into_split();
-
-        Ok(Self {
-            cmd_writer: Mutex::new(cmd_writer),
-            cmd_reader: Mutex::new(cmd_reader),
-            data_writer: Mutex::new(w2),
-            data_reader: Mutex::new(r2),
-            read_timeout: config.read_timeout,
-            write_timeout: config.write_timeout,
-            peer_addr,
-        })
-    }
-
-    pub fn peer_addr(&self) -> SocketAddr {
-        self.peer_addr
-    }
-    pub async fn send_command(&self, line: &str) -> Result<(), ScsPactorError> {
-        let mut writer = self.cmd_writer.lock().await;
-        let fut = writer.send(line.to_string());
-        if let Some(d) = self.write_timeout {
-            let res = timeout(d, fut).await.map_err(|_| ScsPactorError::Timeout)?;
-            res.map_err(|e| ScsPactorError::Io(std::io::Error::other(e.to_string())))?;
-        } else {
-            writer
-                .send(line.to_string())
-                .await
-                .map_err(|e| ScsPactorError::Io(std::io::Error::other(e.to_string())))?;
-        }
-        Ok(())
-    }
-
-    pub async fn read_status_line(&self) -> Result<String, ScsPactorError> {
-        let mut reader = self.cmd_reader.lock().await;
-        let next = if let Some(d) = self.read_timeout {
-            timeout(d, reader.next())
-                .await
-                .map_err(|_| ScsPactorError::Timeout)?
-        } else {
-            reader.next().await
-        };
-        match next {
-            Some(Ok(line)) => Ok(line),
-            Some(Err(e)) => Err(ScsPactorError::Io(std::io::Error::other(e.to_string()))),
-            None => Err(ScsPactorError::Disconnected),
-        }
-    }
-
-    pub async fn set_mycall(&self, callsign: &str) -> Result<(), ScsPactorError> {
-        self.send_command(&format!("MYCALL {}", callsign)).await
-    }
-
-    pub async fn connect_peer(&self, remote_call: &str) -> Result<(), ScsPactorError> {
-        self.send_command(&format!("CONNECT {}", remote_call))
-            .await?;
-        for _ in 0..60 {
-            let line = self.read_status_line().await?;
-            if line.starts_with("DISCONNECTED")
-                || line.starts_with("FAIL")
-                || line.starts_with("NO ")
-            {
-                return Err(ScsPactorError::Io(std::io::Error::other(line)));
-            }
-            if line.starts_with("CONNECTED") {
-                return Ok(());
-            }
-        }
-        Err(ScsPactorError::Timeout)
-    }
-
-    pub async fn write_data(&self, data: &[u8]) -> Result<(), ScsPactorError> {
-        let mut w = self.data_writer.lock().await;
-        let fut = w.write_all(data);
-        if let Some(d) = self.write_timeout {
-            timeout(d, fut)
-                .await
-                .map_err(|_| ScsPactorError::Timeout)??;
-        } else {
-            w.write_all(data).await?;
-        }
-        Ok(())
-    }
-
-    pub async fn read_data(&self, max_len: usize) -> Result<Vec<u8>, ScsPactorError> {
-        let mut r = self.data_reader.lock().await;
-        let mut buf = vec![0u8; max_len];
-        let fut = r.read(&mut buf);
-        let n = if let Some(d) = self.read_timeout {
-            timeout(d, fut)
-                .await
-                .map_err(|_| ScsPactorError::Timeout)??
-        } else {
-            r.read(&mut buf).await?
-        };
-        if n == 0 {
-            return Err(ScsPactorError::Disconnected);
-        }
-        buf.truncate(n);
-        Ok(buf)
-    }
-
-    pub async fn disconnect(&self) -> Result<(), ScsPactorError> {
-        self.send_command("D").await
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn config_resolve_builds() {
-        let _ = ScsPactorConfig::resolve("localhost", 9).await;
-    }
+    async fn next_event(
+        &self,
+        timeout_after: Option<Duration>,
+    ) -> Result<PactorLinkEvent, ScsPactorError>;
 }

--- a/crates/scs_pactor/src/simulator.rs
+++ b/crates/scs_pactor/src/simulator.rs
@@ -1,0 +1,323 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rand::Rng;
+use tokio::sync::{mpsc, Mutex};
+use tokio::time::{sleep, timeout};
+
+use crate::{PactorLinkEvent, PactorLinkStatus, PactorTransport, ScsPactorError};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PactorSpeed {
+    P1,
+    P2,
+    P3,
+    P4,
+}
+
+impl PactorSpeed {
+    pub fn level(self) -> u8 {
+        match self {
+            Self::P1 => 1,
+            Self::P2 => 2,
+            Self::P3 => 3,
+            Self::P4 => 4,
+        }
+    }
+
+    pub fn raw_bps(self) -> u32 {
+        match self {
+            Self::P1 => 200,
+            Self::P2 => 700,
+            Self::P3 => 3200,
+            Self::P4 => 5200,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SimulatedPactorConfig {
+    pub speed: PactorSpeed,
+    pub packet_loss: f32,
+    pub latency: Duration,
+    pub latency_jitter: Duration,
+    pub setup_delay: Duration,
+    pub max_retries: u32,
+    pub read_timeout: Option<Duration>,
+}
+
+impl Default for SimulatedPactorConfig {
+    fn default() -> Self {
+        Self {
+            speed: PactorSpeed::P4,
+            packet_loss: 0.05,
+            latency: Duration::from_millis(250),
+            latency_jitter: Duration::from_millis(50),
+            setup_delay: Duration::from_secs(2),
+            max_retries: 8,
+            read_timeout: Some(Duration::from_secs(10)),
+        }
+    }
+}
+
+struct EndpointState {
+    mycall: Option<String>,
+    connected_to: Option<String>,
+}
+
+struct Endpoint {
+    state: Mutex<EndpointState>,
+    data_tx: mpsc::Sender<Vec<u8>>,
+    data_rx: Mutex<mpsc::Receiver<Vec<u8>>>,
+    event_tx: mpsc::Sender<PactorLinkEvent>,
+    event_rx: Mutex<mpsc::Receiver<PactorLinkEvent>>,
+}
+
+impl Endpoint {
+    fn new() -> Arc<Self> {
+        let (data_tx, data_rx) = mpsc::channel(1024);
+        let (event_tx, event_rx) = mpsc::channel(1024);
+        Arc::new(Self {
+            state: Mutex::new(EndpointState {
+                mycall: None,
+                connected_to: None,
+            }),
+            data_tx,
+            data_rx: Mutex::new(data_rx),
+            event_tx,
+            event_rx: Mutex::new(event_rx),
+        })
+    }
+
+    async fn callsign(&self) -> Option<String> {
+        self.state.lock().await.mycall.clone()
+    }
+}
+
+#[derive(Clone)]
+pub struct SimulatedPactorTransport {
+    local: Arc<Endpoint>,
+    remote: Arc<Endpoint>,
+    config: SimulatedPactorConfig,
+}
+
+pub struct SimulatedPactorPair;
+
+impl SimulatedPactorPair {
+    pub fn new(
+        config: SimulatedPactorConfig,
+    ) -> (SimulatedPactorTransport, SimulatedPactorTransport) {
+        let a = Endpoint::new();
+        let b = Endpoint::new();
+        (
+            SimulatedPactorTransport {
+                local: a.clone(),
+                remote: b.clone(),
+                config: config.clone(),
+            },
+            SimulatedPactorTransport {
+                local: b,
+                remote: a,
+                config,
+            },
+        )
+    }
+}
+
+#[async_trait]
+impl PactorTransport for SimulatedPactorTransport {
+    async fn set_mycall(&self, callsign: &str) -> Result<(), ScsPactorError> {
+        self.local.state.lock().await.mycall = Some(callsign.to_owned());
+        Ok(())
+    }
+
+    async fn connect_peer(&self, remote_call: &str) -> Result<(), ScsPactorError> {
+        let actual_remote = self.remote.callsign().await;
+        if actual_remote.as_deref() != Some(remote_call) {
+            let _ = self
+                .local
+                .event_tx
+                .send(PactorLinkEvent::Status(PactorLinkStatus::LinkFailure))
+                .await;
+            return Err(ScsPactorError::Disconnected);
+        }
+
+        let _ = self
+            .local
+            .event_tx
+            .send(PactorLinkEvent::Status(PactorLinkStatus::Connecting {
+                remote_call: remote_call.to_owned(),
+            }))
+            .await;
+
+        sleep(self.config.setup_delay).await;
+
+        let local_call = self
+            .local
+            .callsign()
+            .await
+            .unwrap_or_else(|| "UNKNOWN".to_owned());
+        self.local.state.lock().await.connected_to = Some(remote_call.to_owned());
+        self.remote.state.lock().await.connected_to = Some(local_call.clone());
+
+        let local_connected = PactorLinkEvent::Status(PactorLinkStatus::Connected {
+            remote_call: remote_call.to_owned(),
+        });
+        let remote_connected = PactorLinkEvent::Status(PactorLinkStatus::Connected {
+            remote_call: local_call,
+        });
+        let _ = self.local.event_tx.send(local_connected).await;
+        let _ = self.remote.event_tx.send(remote_connected).await;
+        Ok(())
+    }
+
+    async fn write_data(&self, data: &[u8]) -> Result<(), ScsPactorError> {
+        if self.local.state.lock().await.connected_to.is_none() {
+            return Err(ScsPactorError::Disconnected);
+        }
+
+        let mut retries = 0;
+        loop {
+            let transmit_time = Duration::from_secs_f64(
+                (data.len() * 8) as f64 / self.config.speed.raw_bps() as f64,
+            );
+            let jitter = if self.config.latency_jitter.is_zero() {
+                Duration::ZERO
+            } else {
+                let jitter_ms = self.config.latency_jitter.as_millis() as u64;
+                Duration::from_millis(rand::rng().random_range(0..=jitter_ms))
+            };
+            sleep(transmit_time + self.config.latency + jitter).await;
+
+            if rand::rng().random::<f32>() >= self.config.packet_loss {
+                self.remote
+                    .data_tx
+                    .send(data.to_vec())
+                    .await
+                    .map_err(|_| ScsPactorError::Disconnected)?;
+                let _ = self
+                    .local
+                    .event_tx
+                    .send(PactorLinkEvent::LinkQuality {
+                        speed_level: self.config.speed.level(),
+                        retries,
+                    })
+                    .await;
+                return Ok(());
+            }
+
+            retries += 1;
+            if retries > self.config.max_retries {
+                let _ = self
+                    .local
+                    .event_tx
+                    .send(PactorLinkEvent::Status(PactorLinkStatus::LinkFailure))
+                    .await;
+                return Err(ScsPactorError::Disconnected);
+            }
+        }
+    }
+
+    async fn read_data(&self, max_len: usize) -> Result<Vec<u8>, ScsPactorError> {
+        let mut rx = self.local.data_rx.lock().await;
+        let read = rx.recv();
+        let mut data = if let Some(d) = self.config.read_timeout {
+            timeout(d, read)
+                .await
+                .map_err(|_| ScsPactorError::Timeout)?
+                .ok_or(ScsPactorError::Disconnected)?
+        } else {
+            read.await.ok_or(ScsPactorError::Disconnected)?
+        };
+        data.truncate(max_len);
+        Ok(data)
+    }
+
+    async fn disconnect(&self) -> Result<(), ScsPactorError> {
+        self.local.state.lock().await.connected_to = None;
+        self.remote.state.lock().await.connected_to = None;
+        let event = PactorLinkEvent::Status(PactorLinkStatus::Disconnected);
+        let _ = self.local.event_tx.send(event.clone()).await;
+        let _ = self.remote.event_tx.send(event).await;
+        Ok(())
+    }
+
+    async fn next_event(
+        &self,
+        timeout_after: Option<Duration>,
+    ) -> Result<PactorLinkEvent, ScsPactorError> {
+        let mut rx = self.local.event_rx.lock().await;
+        let read = rx.recv();
+        if let Some(d) = timeout_after {
+            timeout(d, read)
+                .await
+                .map_err(|_| ScsPactorError::Timeout)?
+                .ok_or(ScsPactorError::Disconnected)
+        } else {
+            read.await.ok_or(ScsPactorError::Disconnected)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn two_simulators_connect_and_exchange_data() {
+        let config = SimulatedPactorConfig {
+            packet_loss: 0.0,
+            latency: Duration::ZERO,
+            latency_jitter: Duration::ZERO,
+            setup_delay: Duration::ZERO,
+            ..Default::default()
+        };
+        let (client, node) = SimulatedPactorPair::new(config);
+        client.set_mycall("CLIENT").await.unwrap();
+        node.set_mycall("NODE").await.unwrap();
+
+        client.connect_peer("NODE").await.unwrap();
+        assert_eq!(
+            client
+                .next_event(Some(Duration::from_millis(50)))
+                .await
+                .unwrap(),
+            PactorLinkEvent::Status(PactorLinkStatus::Connecting {
+                remote_call: "NODE".to_owned()
+            })
+        );
+        assert_eq!(
+            client
+                .next_event(Some(Duration::from_millis(50)))
+                .await
+                .unwrap(),
+            PactorLinkEvent::Status(PactorLinkStatus::Connected {
+                remote_call: "NODE".to_owned()
+            })
+        );
+
+        client.write_data(b"hello").await.unwrap();
+        let received = node.read_data(1024).await.unwrap();
+        assert_eq!(received, b"hello");
+    }
+
+    #[tokio::test]
+    async fn simulator_retries_lost_frames_until_success_or_failure() {
+        let config = SimulatedPactorConfig {
+            packet_loss: 1.0,
+            latency: Duration::ZERO,
+            latency_jitter: Duration::ZERO,
+            setup_delay: Duration::ZERO,
+            max_retries: 2,
+            ..Default::default()
+        };
+        let (client, node) = SimulatedPactorPair::new(config);
+        client.set_mycall("CLIENT").await.unwrap();
+        node.set_mycall("NODE").await.unwrap();
+        client.connect_peer("NODE").await.unwrap();
+
+        let err = client.write_data(b"lost").await.unwrap_err();
+        assert!(matches!(err, ScsPactorError::Disconnected));
+    }
+}

--- a/crates/scs_pactor/src/tcp.rs
+++ b/crates/scs_pactor/src/tcp.rs
@@ -1,0 +1,267 @@
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{lookup_host, TcpStream};
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec};
+
+use crate::{PactorLinkEvent, PactorLinkStatus, PactorTransport, ScsPactorError};
+
+#[derive(Clone, Debug)]
+pub struct ScsPactorConfig {
+    pub addr: SocketAddr,
+    pub read_timeout: Option<Duration>,
+    pub write_timeout: Option<Duration>,
+}
+
+impl ScsPactorConfig {
+    pub async fn resolve(host: &str, port: u16) -> Result<Self, ScsPactorError> {
+        let mut addrs = lookup_host((host, port)).await?;
+        let addr = addrs.next().ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::AddrNotAvailable, "no addresses")
+        })?;
+        Ok(Self {
+            addr,
+            read_timeout: Some(Duration::from_secs(10)),
+            write_timeout: Some(Duration::from_secs(10)),
+        })
+    }
+}
+
+pub struct ScsPactorClient {
+    cmd_writer: Mutex<FramedWrite<tokio::net::tcp::OwnedWriteHalf, LinesCodec>>,
+    cmd_reader: Mutex<FramedRead<tokio::net::tcp::OwnedReadHalf, LinesCodec>>,
+    data_writer: Mutex<tokio::net::tcp::OwnedWriteHalf>,
+    data_reader: Mutex<tokio::net::tcp::OwnedReadHalf>,
+    read_timeout: Option<Duration>,
+    write_timeout: Option<Duration>,
+    peer_addr: SocketAddr,
+}
+
+impl ScsPactorClient {
+    pub async fn connect(config: ScsPactorConfig) -> Result<Self, ScsPactorError> {
+        let stream = TcpStream::connect(config.addr).await?;
+        stream.set_nodelay(true)?;
+        let peer_addr = stream.peer_addr()?;
+
+        let (r, w) = stream.into_split();
+        let cmd_reader = FramedRead::new(r, LinesCodec::new());
+        let cmd_writer = FramedWrite::new(w, LinesCodec::new());
+
+        let stream2 = TcpStream::connect(peer_addr).await?;
+        stream2.set_nodelay(true)?;
+        let (r2, w2) = stream2.into_split();
+
+        Ok(Self {
+            cmd_writer: Mutex::new(cmd_writer),
+            cmd_reader: Mutex::new(cmd_reader),
+            data_writer: Mutex::new(w2),
+            data_reader: Mutex::new(r2),
+            read_timeout: config.read_timeout,
+            write_timeout: config.write_timeout,
+            peer_addr,
+        })
+    }
+
+    pub fn peer_addr(&self) -> SocketAddr {
+        self.peer_addr
+    }
+
+    pub async fn send_command(&self, line: &str) -> Result<(), ScsPactorError> {
+        let mut writer = self.cmd_writer.lock().await;
+        let send = writer.send(line.to_owned());
+        let result = if let Some(d) = self.write_timeout {
+            timeout(d, send)
+                .await
+                .map_err(|_| ScsPactorError::Timeout)?
+        } else {
+            send.await
+        };
+        result.map_err(|e| ScsPactorError::Io(std::io::Error::other(e.to_string())))?;
+        Ok(())
+    }
+
+    pub async fn read_status_line(&self) -> Result<String, ScsPactorError> {
+        let mut reader = self.cmd_reader.lock().await;
+        let next = if let Some(d) = self.read_timeout {
+            timeout(d, reader.next())
+                .await
+                .map_err(|_| ScsPactorError::Timeout)?
+        } else {
+            reader.next().await
+        };
+        match next {
+            Some(Ok(line)) => Ok(line),
+            Some(Err(e)) => Err(ScsPactorError::Io(std::io::Error::other(e.to_string()))),
+            None => Err(ScsPactorError::Disconnected),
+        }
+    }
+
+    fn parse_status_line(line: &str) -> Result<PactorLinkEvent, ScsPactorError> {
+        if let Some(rest) = line.strip_prefix("CONNECTED ") {
+            return Ok(PactorLinkEvent::Status(PactorLinkStatus::Connected {
+                remote_call: rest.trim().to_owned(),
+            }));
+        }
+        if line.starts_with("DISCONNECTED") {
+            return Ok(PactorLinkEvent::Status(PactorLinkStatus::Disconnected));
+        }
+        if line.starts_with("BUSY") {
+            return Ok(PactorLinkEvent::Status(PactorLinkStatus::Busy));
+        }
+        if line.starts_with("LINK FAILURE") || line.starts_with("FAIL") || line.starts_with("NO ") {
+            return Ok(PactorLinkEvent::Status(PactorLinkStatus::LinkFailure));
+        }
+        if let Some(rest) = line.strip_prefix("LINK QUALITY ") {
+            let mut speed_level = 0;
+            let mut retries = 0;
+            for field in rest.split_whitespace() {
+                if let Some(value) = field.strip_prefix("SPEED=") {
+                    speed_level = value.parse().unwrap_or_default();
+                } else if let Some(value) = field.strip_prefix("RETRIES=") {
+                    retries = value.parse().unwrap_or_default();
+                }
+            }
+            return Ok(PactorLinkEvent::LinkQuality {
+                speed_level,
+                retries,
+            });
+        }
+        Err(ScsPactorError::Protocol(line.to_owned()))
+    }
+
+    pub async fn set_mycall(&self, callsign: &str) -> Result<(), ScsPactorError> {
+        self.send_command(&format!("MYCALL {}", callsign)).await
+    }
+
+    pub async fn connect_peer(&self, remote_call: &str) -> Result<(), ScsPactorError> {
+        self.send_command(&format!("CONNECT {}", remote_call))
+            .await?;
+        for _ in 0..60 {
+            let line = self.read_status_line().await?;
+            match Self::parse_status_line(&line)? {
+                PactorLinkEvent::Status(PactorLinkStatus::Connected { .. }) => return Ok(()),
+                PactorLinkEvent::Status(PactorLinkStatus::Busy) => {
+                    return Err(ScsPactorError::Busy)
+                }
+                PactorLinkEvent::Status(
+                    PactorLinkStatus::Disconnected | PactorLinkStatus::LinkFailure,
+                ) => {
+                    return Err(ScsPactorError::Io(std::io::Error::other(line)));
+                }
+                _ => {}
+            }
+        }
+        Err(ScsPactorError::Timeout)
+    }
+
+    pub async fn write_data(&self, data: &[u8]) -> Result<(), ScsPactorError> {
+        let mut w = self.data_writer.lock().await;
+        let write = w.write_all(data);
+        if let Some(d) = self.write_timeout {
+            timeout(d, write)
+                .await
+                .map_err(|_| ScsPactorError::Timeout)??;
+        } else {
+            write.await?;
+        }
+        Ok(())
+    }
+
+    pub async fn read_data(&self, max_len: usize) -> Result<Vec<u8>, ScsPactorError> {
+        let mut r = self.data_reader.lock().await;
+        let mut buf = vec![0u8; max_len];
+        let read = r.read(&mut buf);
+        let n = if let Some(d) = self.read_timeout {
+            timeout(d, read)
+                .await
+                .map_err(|_| ScsPactorError::Timeout)??
+        } else {
+            read.await?
+        };
+        if n == 0 {
+            return Err(ScsPactorError::Disconnected);
+        }
+        buf.truncate(n);
+        Ok(buf)
+    }
+
+    pub async fn disconnect(&self) -> Result<(), ScsPactorError> {
+        self.send_command("D").await
+    }
+}
+
+#[async_trait]
+impl PactorTransport for ScsPactorClient {
+    async fn set_mycall(&self, callsign: &str) -> Result<(), ScsPactorError> {
+        ScsPactorClient::set_mycall(self, callsign).await
+    }
+
+    async fn connect_peer(&self, remote_call: &str) -> Result<(), ScsPactorError> {
+        ScsPactorClient::connect_peer(self, remote_call).await
+    }
+
+    async fn write_data(&self, data: &[u8]) -> Result<(), ScsPactorError> {
+        ScsPactorClient::write_data(self, data).await
+    }
+
+    async fn read_data(&self, max_len: usize) -> Result<Vec<u8>, ScsPactorError> {
+        ScsPactorClient::read_data(self, max_len).await
+    }
+
+    async fn disconnect(&self) -> Result<(), ScsPactorError> {
+        ScsPactorClient::disconnect(self).await
+    }
+
+    async fn next_event(
+        &self,
+        timeout_after: Option<Duration>,
+    ) -> Result<PactorLinkEvent, ScsPactorError> {
+        let read = self.read_status_line();
+        let line = if let Some(d) = timeout_after {
+            timeout(d, read)
+                .await
+                .map_err(|_| ScsPactorError::Timeout)??
+        } else {
+            read.await?
+        };
+        Self::parse_status_line(&line)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn config_resolve_builds() {
+        let _ = ScsPactorConfig::resolve("localhost", 9).await;
+    }
+
+    #[test]
+    fn parse_connected_status() {
+        let event = ScsPactorClient::parse_status_line("CONNECTED NODE1").unwrap();
+        assert_eq!(
+            event,
+            PactorLinkEvent::Status(PactorLinkStatus::Connected {
+                remote_call: "NODE1".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn parse_link_quality_status() {
+        let event = ScsPactorClient::parse_status_line("LINK QUALITY SPEED=4 RETRIES=2").unwrap();
+        assert_eq!(
+            event,
+            PactorLinkEvent::LinkQuality {
+                speed_level: 4,
+                retries: 2
+            }
+        );
+    }
+}

--- a/crates/scs_pactor/src/usb.rs
+++ b/crates/scs_pactor/src/usb.rs
@@ -1,0 +1,381 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::{mpsc, Mutex};
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+
+use crate::hostmode::{encode_frame, HostmodeDecoder, HostmodeFrame};
+use crate::{PactorLinkEvent, PactorLinkStatus, PactorTransport, ScsPactorError};
+
+const COMMAND_CHANNEL: u8 = 0;
+const DATA_CHANNEL: u8 = 1;
+
+#[derive(Clone, Debug)]
+pub struct UsbPactorConfig {
+    pub port: String,
+    pub baud_rate: u32,
+    pub read_timeout: Option<Duration>,
+    pub write_timeout: Option<Duration>,
+    pub command_timeout: Duration,
+}
+
+impl UsbPactorConfig {
+    pub fn new(port: impl Into<String>) -> Self {
+        Self {
+            port: port.into(),
+            baud_rate: 115_200,
+            read_timeout: Some(Duration::from_secs(10)),
+            write_timeout: Some(Duration::from_secs(10)),
+            command_timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+pub struct UsbPactorTransport {
+    writer: Mutex<Box<dyn AsyncWrite + Send + Unpin>>,
+    command_rx: Mutex<mpsc::Receiver<String>>,
+    data_rx: Mutex<mpsc::Receiver<Vec<u8>>>,
+    event_rx: Mutex<mpsc::Receiver<PactorLinkEvent>>,
+    read_task: JoinHandle<()>,
+    read_timeout: Option<Duration>,
+    write_timeout: Option<Duration>,
+    command_timeout: Duration,
+}
+
+impl UsbPactorTransport {
+    pub fn from_stream<S>(stream: S, config: UsbPactorConfig) -> Self
+    where
+        S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    {
+        let (reader, writer) = tokio::io::split(stream);
+        Self::from_split(reader, writer, config)
+    }
+
+    pub fn from_split<R, W>(mut reader: R, writer: W, config: UsbPactorConfig) -> Self
+    where
+        R: AsyncRead + Send + Unpin + 'static,
+        W: AsyncWrite + Send + Unpin + 'static,
+    {
+        let (command_tx, command_rx) = mpsc::channel(1024);
+        let (data_tx, data_rx) = mpsc::channel(1024);
+        let (event_tx, event_rx) = mpsc::channel(1024);
+
+        let read_task = tokio::spawn(async move {
+            let mut decoder = HostmodeDecoder::new();
+            let mut buf = [0u8; 1024];
+
+            loop {
+                let n = match reader.read(&mut buf).await {
+                    Ok(0) => {
+                        let _ = event_tx
+                            .send(PactorLinkEvent::Status(PactorLinkStatus::Disconnected))
+                            .await;
+                        break;
+                    }
+                    Ok(n) => n,
+                    Err(_) => {
+                        let _ = event_tx
+                            .send(PactorLinkEvent::Status(PactorLinkStatus::LinkFailure))
+                            .await;
+                        break;
+                    }
+                };
+
+                decoder.push(&buf[..n]);
+                loop {
+                    match decoder.next_frame() {
+                        Ok(Some(frame)) => {
+                            if route_frame(frame, &command_tx, &data_tx, &event_tx)
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Ok(None) => break,
+                        Err(_) => {
+                            let _ = event_tx
+                                .send(PactorLinkEvent::Status(PactorLinkStatus::LinkFailure))
+                                .await;
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        Self {
+            writer: Mutex::new(Box::new(writer)),
+            command_rx: Mutex::new(command_rx),
+            data_rx: Mutex::new(data_rx),
+            event_rx: Mutex::new(event_rx),
+            read_task,
+            read_timeout: config.read_timeout,
+            write_timeout: config.write_timeout,
+            command_timeout: config.command_timeout,
+        }
+    }
+
+    async fn send_frame(&self, channel: u8, payload: &[u8]) -> Result<(), ScsPactorError> {
+        let encoded = encode_frame(&HostmodeFrame::new(channel, payload.to_vec()))?;
+        let mut writer = self.writer.lock().await;
+        let write = writer.write_all(&encoded);
+        if let Some(d) = self.write_timeout {
+            timeout(d, write)
+                .await
+                .map_err(|_| ScsPactorError::Timeout)??;
+        } else {
+            write.await?;
+        }
+        writer.flush().await?;
+        Ok(())
+    }
+
+    pub async fn send_command(&self, line: &str) -> Result<(), ScsPactorError> {
+        self.send_frame(COMMAND_CHANNEL, line.as_bytes()).await
+    }
+
+    pub async fn read_status_line(&self) -> Result<String, ScsPactorError> {
+        let mut rx = self.command_rx.lock().await;
+        let read = rx.recv();
+        if let Some(d) = self.read_timeout {
+            timeout(d, read)
+                .await
+                .map_err(|_| ScsPactorError::Timeout)?
+                .ok_or(ScsPactorError::Disconnected)
+        } else {
+            read.await.ok_or(ScsPactorError::Disconnected)
+        }
+    }
+
+    fn parse_status_line(line: &str) -> Result<PactorLinkEvent, ScsPactorError> {
+        if let Some(rest) = line.strip_prefix("CONNECTED ") {
+            return Ok(PactorLinkEvent::Status(PactorLinkStatus::Connected {
+                remote_call: rest.trim().to_owned(),
+            }));
+        }
+        if let Some(rest) = line.strip_prefix("CONNECTING ") {
+            return Ok(PactorLinkEvent::Status(PactorLinkStatus::Connecting {
+                remote_call: rest.trim().to_owned(),
+            }));
+        }
+        if line.starts_with("DISCONNECTED") {
+            return Ok(PactorLinkEvent::Status(PactorLinkStatus::Disconnected));
+        }
+        if line.starts_with("BUSY") {
+            return Ok(PactorLinkEvent::Status(PactorLinkStatus::Busy));
+        }
+        if line.starts_with("LINK FAILURE") || line.starts_with("FAIL") || line.starts_with("NO ") {
+            return Ok(PactorLinkEvent::Status(PactorLinkStatus::LinkFailure));
+        }
+        if let Some(rest) = line.strip_prefix("LINK QUALITY ") {
+            let mut speed_level = 0;
+            let mut retries = 0;
+            for field in rest.split_whitespace() {
+                if let Some(value) = field.strip_prefix("SPEED=") {
+                    speed_level = value.parse().unwrap_or_default();
+                } else if let Some(value) = field.strip_prefix("RETRIES=") {
+                    retries = value.parse().unwrap_or_default();
+                }
+            }
+            return Ok(PactorLinkEvent::LinkQuality {
+                speed_level,
+                retries,
+            });
+        }
+        Err(ScsPactorError::Protocol(line.to_owned()))
+    }
+}
+
+impl Drop for UsbPactorTransport {
+    fn drop(&mut self) {
+        self.read_task.abort();
+    }
+}
+
+async fn route_frame(
+    frame: HostmodeFrame,
+    command_tx: &mpsc::Sender<String>,
+    data_tx: &mpsc::Sender<Vec<u8>>,
+    event_tx: &mpsc::Sender<PactorLinkEvent>,
+) -> Result<(), ScsPactorError> {
+    match frame.channel {
+        COMMAND_CHANNEL => {
+            let line = String::from_utf8(frame.payload)
+                .map_err(|e| ScsPactorError::Protocol(e.to_string()))?;
+            if let Ok(event) = UsbPactorTransport::parse_status_line(&line) {
+                let _ = event_tx.send(event).await;
+            }
+            command_tx
+                .send(line)
+                .await
+                .map_err(|_| ScsPactorError::Disconnected)?;
+        }
+        DATA_CHANNEL => {
+            data_tx
+                .send(frame.payload)
+                .await
+                .map_err(|_| ScsPactorError::Disconnected)?;
+        }
+        other => {
+            return Err(ScsPactorError::Protocol(format!(
+                "unknown hostmode channel {other}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl PactorTransport for UsbPactorTransport {
+    async fn set_mycall(&self, callsign: &str) -> Result<(), ScsPactorError> {
+        self.send_command(&format!("MYCALL {callsign}")).await
+    }
+
+    async fn connect_peer(&self, remote_call: &str) -> Result<(), ScsPactorError> {
+        self.send_command(&format!("CONNECT {remote_call}")).await?;
+        loop {
+            let line = timeout(self.command_timeout, self.read_status_line())
+                .await
+                .map_err(|_| ScsPactorError::Timeout)??;
+            match Self::parse_status_line(&line)? {
+                PactorLinkEvent::Status(PactorLinkStatus::Connected { .. }) => return Ok(()),
+                PactorLinkEvent::Status(PactorLinkStatus::Busy) => {
+                    return Err(ScsPactorError::Busy)
+                }
+                PactorLinkEvent::Status(
+                    PactorLinkStatus::Disconnected | PactorLinkStatus::LinkFailure,
+                ) => return Err(ScsPactorError::Io(std::io::Error::other(line))),
+                _ => {}
+            }
+        }
+    }
+
+    async fn write_data(&self, data: &[u8]) -> Result<(), ScsPactorError> {
+        self.send_frame(DATA_CHANNEL, data).await
+    }
+
+    async fn read_data(&self, max_len: usize) -> Result<Vec<u8>, ScsPactorError> {
+        let mut rx = self.data_rx.lock().await;
+        let read = rx.recv();
+        let mut data = if let Some(d) = self.read_timeout {
+            timeout(d, read)
+                .await
+                .map_err(|_| ScsPactorError::Timeout)?
+                .ok_or(ScsPactorError::Disconnected)?
+        } else {
+            read.await.ok_or(ScsPactorError::Disconnected)?
+        };
+        data.truncate(max_len);
+        Ok(data)
+    }
+
+    async fn disconnect(&self) -> Result<(), ScsPactorError> {
+        self.send_command("D").await
+    }
+
+    async fn next_event(
+        &self,
+        timeout_after: Option<Duration>,
+    ) -> Result<PactorLinkEvent, ScsPactorError> {
+        let mut rx = self.event_rx.lock().await;
+        let read = rx.recv();
+        if let Some(d) = timeout_after {
+            timeout(d, read)
+                .await
+                .map_err(|_| ScsPactorError::Timeout)?
+                .ok_or(ScsPactorError::Disconnected)
+        } else {
+            read.await.ok_or(ScsPactorError::Disconnected)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{duplex, AsyncReadExt};
+
+    use super::*;
+    use crate::hostmode::decode_frame;
+
+    fn test_config() -> UsbPactorConfig {
+        UsbPactorConfig {
+            port: "mock".to_owned(),
+            baud_rate: 115_200,
+            read_timeout: Some(Duration::from_millis(100)),
+            write_timeout: Some(Duration::from_millis(100)),
+            command_timeout: Duration::from_millis(100),
+        }
+    }
+
+    #[tokio::test]
+    async fn usb_transport_writes_commands_as_hostmode_frames() {
+        let (transport_side, mut modem_side) = duplex(1024);
+        let transport = UsbPactorTransport::from_stream(transport_side, test_config());
+
+        transport.set_mycall("N0CALL").await.unwrap();
+
+        let mut buf = [0u8; 1024];
+        let n = modem_side.read(&mut buf).await.unwrap();
+        let frame = decode_frame(&buf[..n]).unwrap();
+        assert_eq!(frame.channel, COMMAND_CHANNEL);
+        assert_eq!(frame.payload, b"MYCALL N0CALL");
+    }
+
+    #[tokio::test]
+    async fn usb_transport_demuxes_command_events_and_data() {
+        let (transport_side, mut modem_side) = duplex(2048);
+        let transport = UsbPactorTransport::from_stream(transport_side, test_config());
+
+        let status = encode_frame(&HostmodeFrame::new(
+            COMMAND_CHANNEL,
+            b"CONNECTED NODE".to_vec(),
+        ))
+        .unwrap();
+        let data = encode_frame(&HostmodeFrame::new(DATA_CHANNEL, b"payload".to_vec())).unwrap();
+
+        modem_side.write_all(&[0x00, 0x01, 0x02]).await.unwrap();
+        modem_side.write_all(&status).await.unwrap();
+        modem_side.write_all(&data).await.unwrap();
+
+        assert_eq!(
+            transport
+                .next_event(Some(Duration::from_millis(100)))
+                .await
+                .unwrap(),
+            PactorLinkEvent::Status(PactorLinkStatus::Connected {
+                remote_call: "NODE".to_owned()
+            })
+        );
+        assert_eq!(
+            transport.read_status_line().await.unwrap(),
+            "CONNECTED NODE"
+        );
+        assert_eq!(transport.read_data(1024).await.unwrap(), b"payload");
+    }
+
+    #[tokio::test]
+    async fn usb_transport_connect_peer_waits_for_connected_status() {
+        let (transport_side, mut modem_side) = duplex(2048);
+        let transport = UsbPactorTransport::from_stream(transport_side, test_config());
+
+        let modem = tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            let n = modem_side.read(&mut buf).await.unwrap();
+            let frame = decode_frame(&buf[..n]).unwrap();
+            assert_eq!(frame.payload, b"CONNECT NODE");
+
+            let connected = encode_frame(&HostmodeFrame::new(
+                COMMAND_CHANNEL,
+                b"CONNECTED NODE".to_vec(),
+            ))
+            .unwrap();
+            modem_side.write_all(&connected).await.unwrap();
+        });
+
+        transport.connect_peer("NODE").await.unwrap();
+        modem.await.unwrap();
+    }
+}


### PR DESCRIPTION
 ## Summary

  Adds the initial PACTOR transport foundation for `crates/scs_pactor`.

  This introduces a shared `PactorTransport` trait, keeps the existing TCP client available behind that trait, and adds the first simulator, Hostmode framing, and USB transport core needed for later real-modem support.

  ## Changes

  - Add `PactorTransport` trait with command, data, disconnect, and link-event methods.
  - Move the existing TCP SCS client into `tcp.rs` and implement `PactorTransport`.
  - Add structured link status and link quality events.
  - Add Hostmode frame encode/decode with CRC validation and resync-after-garbage support.
  - Add an initial in-process PACTOR simulator with speed levels, latency, packet loss, and ARQ-style retries.
  - Add USB transport core that reads/writes Hostmode frames over a single async stream.
  - Add mock-serial tests using `tokio::io::duplex`.

  ## Verification

  - `cargo test -p scs_pactor`

  ## Notes

  This PR does not yet open a real USB serial device. The USB transport core is testable with mock streams.