### PR TITLE
feat: pactor hostmode hardening

### DIFF
--- a/crates/scs_pactor/src/hostmode.rs
+++ b/crates/scs_pactor/src/hostmode.rs
@@ -1,10 +1,14 @@
 use crate::ScsPactorError;
 
-const FRAME_START: u8 = 0xAA;
+const FRAME_SYNC: [u8; 2] = [0xAA, 0xAA];
+const STUFF_BYTE: u8 = 0x00;
+const REQUEST_PACKET: [u8; 4] = [0xAA, 0xAA, 0xAA, 0x55];
+const MAX_STANDARD_PAYLOAD_LEN: usize = 256;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HostmodeFrame {
     pub channel: u8,
+    pub code: u8,
     pub payload: Vec<u8>,
 }
 
@@ -12,63 +16,104 @@ impl HostmodeFrame {
     pub fn new(channel: u8, payload: impl Into<Vec<u8>>) -> Self {
         Self {
             channel,
+            code: 0,
+            payload: payload.into(),
+        }
+    }
+
+    pub fn with_code(channel: u8, code: u8, payload: impl Into<Vec<u8>>) -> Self {
+        Self {
+            channel,
+            code,
             payload: payload.into(),
         }
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum HostmodePacket {
+    Frame(HostmodeFrame),
+    RepeatRequest,
+}
+
 pub fn encode_frame(frame: &HostmodeFrame) -> Result<Vec<u8>, ScsPactorError> {
-    if frame.payload.len() > u16::MAX as usize {
+    if frame.payload.len() > MAX_STANDARD_PAYLOAD_LEN {
         return Err(ScsPactorError::ExceedsMtu(frame.payload.len()));
     }
 
-    let len = frame.payload.len() as u16;
-    let mut encoded = Vec::with_capacity(frame.payload.len() + 6);
-    encoded.push(FRAME_START);
-    encoded.push(frame.channel);
-    encoded.extend_from_slice(&len.to_be_bytes());
-    encoded.extend_from_slice(&frame.payload);
+    let mut body = Vec::with_capacity(frame.payload.len() + 5);
+    body.push(frame.channel);
+    body.push(frame.code);
+    body.push(length_minus_one(frame.payload.len())?);
+    body.extend_from_slice(&frame.payload);
 
-    let crc = crc16_ccitt_false(&encoded[1..]);
-    encoded.extend_from_slice(&crc.to_be_bytes());
+    let crc = crc16_ccitt_false(&body);
+    body.extend_from_slice(&crc.to_le_bytes());
+
+    let mut encoded = Vec::with_capacity(body.len() + 2);
+    encoded.extend_from_slice(&FRAME_SYNC);
+    stuff_bytes(&body, &mut encoded);
     Ok(encoded)
 }
 
+pub fn encode_repeat_request() -> Vec<u8> {
+    REQUEST_PACKET.to_vec()
+}
+
 pub fn decode_frame(bytes: &[u8]) -> Result<HostmodeFrame, ScsPactorError> {
-    if bytes.len() < 6 {
+    match decode_packet(bytes)? {
+        HostmodePacket::Frame(frame) => Ok(frame),
+        HostmodePacket::RepeatRequest => Err(ScsPactorError::Protocol(
+            "hostmode repeat request is not a data frame".to_owned(),
+        )),
+    }
+}
+
+pub fn decode_packet(bytes: &[u8]) -> Result<HostmodePacket, ScsPactorError> {
+    if bytes == REQUEST_PACKET {
+        return Ok(HostmodePacket::RepeatRequest);
+    }
+    if bytes.len() < 7 {
         return Err(ScsPactorError::Protocol(
             "hostmode frame too short".to_owned(),
         ));
     }
-    if bytes[0] != FRAME_START {
+    if !bytes.starts_with(&FRAME_SYNC) {
         return Err(ScsPactorError::Protocol(
-            "hostmode frame start missing".to_owned(),
+            "hostmode frame sync missing".to_owned(),
         ));
     }
 
-    let channel = bytes[1];
-    let len = u16::from_be_bytes([bytes[2], bytes[3]]) as usize;
-    let expected_len = 1 + 1 + 2 + len + 2;
-    if bytes.len() != expected_len {
-        return Err(ScsPactorError::Protocol(format!(
-            "hostmode frame length mismatch: expected {expected_len}, got {}",
-            bytes.len()
-        )));
+    let body = destuff_bytes(&bytes[2..])?;
+    if body.len() < 5 {
+        return Err(ScsPactorError::Protocol(
+            "hostmode frame body too short".to_owned(),
+        ));
     }
 
-    let crc_offset = bytes.len() - 2;
-    let expected_crc = u16::from_be_bytes([bytes[crc_offset], bytes[crc_offset + 1]]);
-    let actual_crc = crc16_ccitt_false(&bytes[1..crc_offset]);
+    let crc_offset = body.len() - 2;
+    let expected_crc = u16::from_le_bytes([body[crc_offset], body[crc_offset + 1]]);
+    let actual_crc = crc16_ccitt_false(&body[..crc_offset]);
     if actual_crc != expected_crc {
         return Err(ScsPactorError::Protocol(
             "hostmode frame crc mismatch".to_owned(),
         ));
     }
 
-    Ok(HostmodeFrame {
-        channel,
-        payload: bytes[4..crc_offset].to_vec(),
-    })
+    let payload_len = payload_len_from_minus_one(body[2]);
+    let expected_body_len = 3 + payload_len + 2;
+    if body.len() != expected_body_len {
+        return Err(ScsPactorError::Protocol(format!(
+            "hostmode frame length mismatch: expected body {expected_body_len}, got {}",
+            body.len()
+        )));
+    }
+
+    Ok(HostmodePacket::Frame(HostmodeFrame {
+        channel: body[0],
+        code: body[1],
+        payload: body[3..crc_offset].to_vec(),
+    }))
 }
 
 #[derive(Debug, Default)]
@@ -86,26 +131,170 @@ impl HostmodeDecoder {
     }
 
     pub fn next_frame(&mut self) -> Result<Option<HostmodeFrame>, ScsPactorError> {
-        let Some(start) = self.buffer.iter().position(|byte| *byte == FRAME_START) else {
-            self.buffer.clear();
+        match self.next_packet()? {
+            Some(HostmodePacket::Frame(frame)) => Ok(Some(frame)),
+            Some(HostmodePacket::RepeatRequest) => Err(ScsPactorError::Protocol(
+                "hostmode repeat request is not a data frame".to_owned(),
+            )),
+            None => Ok(None),
+        }
+    }
+
+    pub fn next_packet(&mut self) -> Result<Option<HostmodePacket>, ScsPactorError> {
+        let Some(start) = find_sync(&self.buffer) else {
+            retain_possible_partial_sync(&mut self.buffer);
             return Ok(None);
         };
         if start > 0 {
             self.buffer.drain(..start);
         }
 
-        if self.buffer.len() < 4 {
+        if self.buffer.starts_with(&REQUEST_PACKET) {
+            self.buffer.drain(..REQUEST_PACKET.len());
+            return Ok(Some(HostmodePacket::RepeatRequest));
+        }
+
+        if self.buffer.len() < 5 {
             return Ok(None);
         }
 
-        let payload_len = u16::from_be_bytes([self.buffer[2], self.buffer[3]]) as usize;
-        let frame_len = 1 + 1 + 2 + payload_len + 2;
-        if self.buffer.len() < frame_len {
+        let Some(body_len) = decoded_body_len(&self.buffer[2..])? else {
             return Ok(None);
-        }
+        };
+        let Some(raw_len) = raw_len_for_destuffed_body(&self.buffer[2..], body_len)? else {
+            return Ok(None);
+        };
 
-        let frame_bytes: Vec<u8> = self.buffer.drain(..frame_len).collect();
-        decode_frame(&frame_bytes).map(Some)
+        let packet_len = 2 + raw_len;
+        let packet: Vec<u8> = self.buffer.drain(..packet_len).collect();
+        decode_packet(&packet).map(Some)
+    }
+}
+
+fn length_minus_one(payload_len: usize) -> Result<u8, ScsPactorError> {
+    if payload_len == 0 {
+        return Err(ScsPactorError::Protocol(
+            "hostmode payload cannot be empty".to_owned(),
+        ));
+    }
+    if payload_len > MAX_STANDARD_PAYLOAD_LEN {
+        return Err(ScsPactorError::ExceedsMtu(payload_len));
+    }
+    Ok((payload_len - 1) as u8)
+}
+
+fn payload_len_from_minus_one(length_byte: u8) -> usize {
+    length_byte as usize + 1
+}
+
+fn stuff_bytes(input: &[u8], output: &mut Vec<u8>) {
+    for byte in input {
+        output.push(*byte);
+        if *byte == 0xAA {
+            output.push(STUFF_BYTE);
+        }
+    }
+}
+
+fn destuff_bytes(input: &[u8]) -> Result<Vec<u8>, ScsPactorError> {
+    let mut output = Vec::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        let byte = input[i];
+        output.push(byte);
+        i += 1;
+        if byte == 0xAA {
+            match input.get(i) {
+                Some(0x00) => i += 1,
+                Some(_) => {
+                    return Err(ScsPactorError::Protocol(
+                        "hostmode byte-stuffing error".to_owned(),
+                    ))
+                }
+                None => {
+                    return Err(ScsPactorError::Protocol(
+                        "hostmode truncated stuffed byte".to_owned(),
+                    ))
+                }
+            }
+        }
+    }
+    Ok(output)
+}
+
+fn find_sync(bytes: &[u8]) -> Option<usize> {
+    bytes.windows(2).position(|window| window == FRAME_SYNC)
+}
+
+fn retain_possible_partial_sync(buffer: &mut Vec<u8>) {
+    if buffer.last() == Some(&0xAA) {
+        buffer.drain(..buffer.len() - 1);
+    } else {
+        buffer.clear();
+    }
+}
+
+fn decoded_body_len(raw_body: &[u8]) -> Result<Option<usize>, ScsPactorError> {
+    let Some(header) = destuffed_prefix(raw_body, 3)? else {
+        return Ok(None);
+    };
+    Ok(Some(3 + payload_len_from_minus_one(header[2]) + 2))
+}
+
+fn raw_len_for_destuffed_body(
+    raw_body: &[u8],
+    expected_destuffed_len: usize,
+) -> Result<Option<usize>, ScsPactorError> {
+    let mut destuffed = 0;
+    let mut raw = 0;
+    while raw < raw_body.len() && destuffed < expected_destuffed_len {
+        let byte = raw_body[raw];
+        raw += 1;
+        destuffed += 1;
+        if byte == 0xAA {
+            match raw_body.get(raw) {
+                Some(0x00) => raw += 1,
+                Some(_) => {
+                    return Err(ScsPactorError::Protocol(
+                        "hostmode byte-stuffing error".to_owned(),
+                    ))
+                }
+                None => return Ok(None),
+            }
+        }
+    }
+
+    if destuffed == expected_destuffed_len {
+        Ok(Some(raw))
+    } else {
+        Ok(None)
+    }
+}
+
+fn destuffed_prefix(raw_body: &[u8], len: usize) -> Result<Option<Vec<u8>>, ScsPactorError> {
+    let mut output = Vec::with_capacity(len);
+    let mut raw = 0;
+    while raw < raw_body.len() && output.len() < len {
+        let byte = raw_body[raw];
+        output.push(byte);
+        raw += 1;
+        if byte == 0xAA {
+            match raw_body.get(raw) {
+                Some(0x00) => raw += 1,
+                Some(_) => {
+                    return Err(ScsPactorError::Protocol(
+                        "hostmode byte-stuffing error".to_owned(),
+                    ))
+                }
+                None => return Ok(None),
+            }
+        }
+    }
+
+    if output.len() == len {
+        Ok(Some(output))
+    } else {
+        Ok(None)
     }
 }
 
@@ -130,15 +319,25 @@ mod tests {
 
     #[test]
     fn hostmode_frame_round_trip() {
-        let frame = HostmodeFrame::new(1, b"MYCALL N0CALL".to_vec());
+        let frame = HostmodeFrame::with_code(1, b'C', b"DL1ZAM".to_vec());
         let encoded = encode_frame(&frame).unwrap();
+        assert!(encoded.starts_with(&FRAME_SYNC));
+        let decoded = decode_frame(&encoded).unwrap();
+        assert_eq!(decoded, frame);
+    }
+
+    #[test]
+    fn hostmode_frame_stuffs_0xaa_bytes() {
+        let frame = HostmodeFrame::with_code(2, 0, vec![0x01, 0xAA, 0x02]);
+        let encoded = encode_frame(&frame).unwrap();
+        assert!(encoded.windows(2).any(|window| window == [0xAA, 0x00]));
         let decoded = decode_frame(&encoded).unwrap();
         assert_eq!(decoded, frame);
     }
 
     #[test]
     fn hostmode_frame_rejects_bad_crc() {
-        let frame = HostmodeFrame::new(2, b"payload".to_vec());
+        let frame = HostmodeFrame::with_code(2, 0, b"payload".to_vec());
         let mut encoded = encode_frame(&frame).unwrap();
         let last = encoded.len() - 1;
         encoded[last] ^= 0x01;
@@ -147,8 +346,15 @@ mod tests {
     }
 
     #[test]
+    fn hostmode_frame_rejects_empty_payload() {
+        let frame = HostmodeFrame::with_code(2, b'D', Vec::new());
+        let err = encode_frame(&frame).unwrap_err();
+        assert!(matches!(err, ScsPactorError::Protocol(_)));
+    }
+
+    #[test]
     fn decoder_resyncs_after_garbage() {
-        let frame = HostmodeFrame::new(7, b"D".to_vec());
+        let frame = HostmodeFrame::with_code(7, b'D', b"X".to_vec());
         let encoded = encode_frame(&frame).unwrap();
 
         let mut decoder = HostmodeDecoder::new();
@@ -160,6 +366,16 @@ mod tests {
 
         decoder.push(&encoded[3..]);
         assert_eq!(decoder.next_frame().unwrap(), Some(frame));
+    }
+
+    #[test]
+    fn decoder_recognizes_repeat_request() {
+        let mut decoder = HostmodeDecoder::new();
+        decoder.push(&encode_repeat_request());
+        assert_eq!(
+            decoder.next_packet().unwrap(),
+            Some(HostmodePacket::RepeatRequest)
+        );
     }
 
     #[test]

--- a/crates/scs_pactor/src/usb.rs
+++ b/crates/scs_pactor/src/usb.rs
@@ -118,8 +118,8 @@ impl UsbPactorTransport {
         }
     }
 
-    async fn send_frame(&self, channel: u8, payload: &[u8]) -> Result<(), ScsPactorError> {
-        let encoded = encode_frame(&HostmodeFrame::new(channel, payload.to_vec()))?;
+    async fn send_hostmode_frame(&self, frame: HostmodeFrame) -> Result<(), ScsPactorError> {
+        let encoded = encode_frame(&frame)?;
         let mut writer = self.writer.lock().await;
         let write = writer.write_all(&encoded);
         if let Some(d) = self.write_timeout {
@@ -133,8 +133,38 @@ impl UsbPactorTransport {
         Ok(())
     }
 
+    async fn send_frame(&self, channel: u8, payload: &[u8]) -> Result<(), ScsPactorError> {
+        self.send_hostmode_frame(HostmodeFrame::new(channel, payload.to_vec()))
+            .await
+    }
+
+    async fn send_host_command(&self, code: u8, payload: &[u8]) -> Result<(), ScsPactorError> {
+        let payload = if payload.is_empty() {
+            vec![0]
+        } else {
+            payload.to_vec()
+        };
+        self.send_hostmode_frame(HostmodeFrame::with_code(COMMAND_CHANNEL, code, payload))
+            .await
+    }
+
     pub async fn send_command(&self, line: &str) -> Result<(), ScsPactorError> {
-        self.send_frame(COMMAND_CHANNEL, line.as_bytes()).await
+        let trimmed = line.trim();
+        let mut parts = trimmed.splitn(2, char::is_whitespace);
+        let command = parts.next().unwrap_or_default();
+        let payload = parts.next().unwrap_or_default().trim_start();
+        let code = match command {
+            "MYCALL" => b'I',
+            "CONNECT" => b'C',
+            "DISCONNECT" => b'D',
+            command if command.len() == 1 => command.as_bytes()[0],
+            _ => {
+                return Err(ScsPactorError::Protocol(format!(
+                    "unsupported hostmode command {command}"
+                )))
+            }
+        };
+        self.send_host_command(code, payload.as_bytes()).await
     }
 
     pub async fn read_status_line(&self) -> Result<String, ScsPactorError> {
@@ -231,11 +261,11 @@ async fn route_frame(
 #[async_trait]
 impl PactorTransport for UsbPactorTransport {
     async fn set_mycall(&self, callsign: &str) -> Result<(), ScsPactorError> {
-        self.send_command(&format!("MYCALL {callsign}")).await
+        self.send_host_command(b'I', callsign.as_bytes()).await
     }
 
     async fn connect_peer(&self, remote_call: &str) -> Result<(), ScsPactorError> {
-        self.send_command(&format!("CONNECT {remote_call}")).await?;
+        self.send_host_command(b'C', remote_call.as_bytes()).await?;
         loop {
             let line = timeout(self.command_timeout, self.read_status_line())
                 .await
@@ -273,7 +303,7 @@ impl PactorTransport for UsbPactorTransport {
     }
 
     async fn disconnect(&self) -> Result<(), ScsPactorError> {
-        self.send_command("D").await
+        self.send_host_command(b'D', &[]).await
     }
 
     async fn next_event(
@@ -321,7 +351,8 @@ mod tests {
         let n = modem_side.read(&mut buf).await.unwrap();
         let frame = decode_frame(&buf[..n]).unwrap();
         assert_eq!(frame.channel, COMMAND_CHANNEL);
-        assert_eq!(frame.payload, b"MYCALL N0CALL");
+        assert_eq!(frame.code, b'I');
+        assert_eq!(frame.payload, b"N0CALL");
     }
 
     #[tokio::test]
@@ -365,7 +396,9 @@ mod tests {
             let mut buf = [0u8; 1024];
             let n = modem_side.read(&mut buf).await.unwrap();
             let frame = decode_frame(&buf[..n]).unwrap();
-            assert_eq!(frame.payload, b"CONNECT NODE");
+            assert_eq!(frame.channel, COMMAND_CHANNEL);
+            assert_eq!(frame.code, b'C');
+            assert_eq!(frame.payload, b"NODE");
 
             let connected = encode_frame(&HostmodeFrame::new(
                 COMMAND_CHANNEL,
@@ -377,5 +410,20 @@ mod tests {
 
         transport.connect_peer("NODE").await.unwrap();
         modem.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn usb_transport_writes_disconnect_as_hostmode_command() {
+        let (transport_side, mut modem_side) = duplex(1024);
+        let transport = UsbPactorTransport::from_stream(transport_side, test_config());
+
+        transport.disconnect().await.unwrap();
+
+        let mut buf = [0u8; 1024];
+        let n = modem_side.read(&mut buf).await.unwrap();
+        let frame = decode_frame(&buf[..n]).unwrap();
+        assert_eq!(frame.channel, COMMAND_CHANNEL);
+        assert_eq!(frame.code, b'D');
+        assert_eq!(frame.payload, vec![0]);
     }
 }

--- a/crates/scs_pactor/src/usb.rs
+++ b/crates/scs_pactor/src/usb.rs
@@ -6,11 +6,14 @@ use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
 
-use crate::hostmode::{encode_frame, HostmodeDecoder, HostmodeFrame};
+use crate::hostmode::{encode_frame, HostmodeDecoder, HostmodeFrame, HostmodePacket};
 use crate::{PactorLinkEvent, PactorLinkStatus, PactorTransport, ScsPactorError};
 
 const COMMAND_CHANNEL: u8 = 0;
 const DATA_CHANNEL: u8 = 1;
+const STATUS_CHANNEL: u8 = 254;
+const EXTENDED_POLL_CHANNEL: u8 = 255;
+const MAX_HOSTMODE_RETRIES: u8 = 3;
 
 #[derive(Clone, Debug)]
 pub struct UsbPactorConfig {
@@ -38,6 +41,8 @@ pub struct UsbPactorTransport {
     command_rx: Mutex<mpsc::Receiver<String>>,
     data_rx: Mutex<mpsc::Receiver<Vec<u8>>>,
     event_rx: Mutex<mpsc::Receiver<PactorLinkEvent>>,
+    packet_rx: Mutex<mpsc::Receiver<HostmodePacket>>,
+    transaction_lock: Mutex<()>,
     read_task: JoinHandle<()>,
     read_timeout: Option<Duration>,
     write_timeout: Option<Duration>,
@@ -61,6 +66,7 @@ impl UsbPactorTransport {
         let (command_tx, command_rx) = mpsc::channel(1024);
         let (data_tx, data_rx) = mpsc::channel(1024);
         let (event_tx, event_rx) = mpsc::channel(1024);
+        let (packet_tx, packet_rx) = mpsc::channel(1024);
 
         let read_task = tokio::spawn(async move {
             let mut decoder = HostmodeDecoder::new();
@@ -85,14 +91,18 @@ impl UsbPactorTransport {
 
                 decoder.push(&buf[..n]);
                 loop {
-                    match decoder.next_frame() {
-                        Ok(Some(frame)) => {
+                    match decoder.next_packet() {
+                        Ok(Some(HostmodePacket::Frame(frame))) => {
+                            let _ = packet_tx.send(HostmodePacket::Frame(frame.clone())).await;
                             if route_frame(frame, &command_tx, &data_tx, &event_tx)
                                 .await
                                 .is_err()
                             {
                                 break;
                             }
+                        }
+                        Ok(Some(HostmodePacket::RepeatRequest)) => {
+                            let _ = packet_tx.send(HostmodePacket::RepeatRequest).await;
                         }
                         Ok(None) => break,
                         Err(_) => {
@@ -111,6 +121,8 @@ impl UsbPactorTransport {
             command_rx: Mutex::new(command_rx),
             data_rx: Mutex::new(data_rx),
             event_rx: Mutex::new(event_rx),
+            packet_rx: Mutex::new(packet_rx),
+            transaction_lock: Mutex::new(()),
             read_task,
             read_timeout: config.read_timeout,
             write_timeout: config.write_timeout,
@@ -120,8 +132,12 @@ impl UsbPactorTransport {
 
     async fn send_hostmode_frame(&self, frame: HostmodeFrame) -> Result<(), ScsPactorError> {
         let encoded = encode_frame(&frame)?;
+        self.write_encoded_frame(&encoded).await
+    }
+
+    async fn write_encoded_frame(&self, encoded: &[u8]) -> Result<(), ScsPactorError> {
         let mut writer = self.writer.lock().await;
-        let write = writer.write_all(&encoded);
+        let write = writer.write_all(encoded);
         if let Some(d) = self.write_timeout {
             timeout(d, write)
                 .await
@@ -131,6 +147,75 @@ impl UsbPactorTransport {
         }
         writer.flush().await?;
         Ok(())
+    }
+
+    pub async fn hostmode_transaction(
+        &self,
+        frame: HostmodeFrame,
+    ) -> Result<HostmodeFrame, ScsPactorError> {
+        let _transaction = self.transaction_lock.lock().await;
+        let encoded = encode_frame(&frame)?;
+        let mut retries = 0;
+
+        loop {
+            self.write_encoded_frame(&encoded).await?;
+            match self.recv_hostmode_packet(self.command_timeout).await? {
+                HostmodePacket::Frame(response) => return Ok(response),
+                HostmodePacket::RepeatRequest => {
+                    retries += 1;
+                    if retries > MAX_HOSTMODE_RETRIES {
+                        return Err(ScsPactorError::Protocol(
+                            "hostmode repeat request limit exceeded".to_owned(),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    async fn recv_hostmode_packet(
+        &self,
+        timeout_after: Duration,
+    ) -> Result<HostmodePacket, ScsPactorError> {
+        let mut rx = self.packet_rx.lock().await;
+        timeout(timeout_after, rx.recv())
+            .await
+            .map_err(|_| ScsPactorError::Timeout)?
+            .ok_or(ScsPactorError::Disconnected)
+    }
+
+    pub async fn poll_channel(&self, channel: u8) -> Result<HostmodeFrame, ScsPactorError> {
+        self.hostmode_transaction(HostmodeFrame::with_code(channel, b'G', vec![0]))
+            .await
+    }
+
+    pub async fn poll_pending_channels(&self) -> Result<Vec<u8>, ScsPactorError> {
+        let response = self.poll_channel(EXTENDED_POLL_CHANNEL).await?;
+        if response.channel != EXTENDED_POLL_CHANNEL {
+            return Err(ScsPactorError::Protocol(format!(
+                "expected channel {EXTENDED_POLL_CHANNEL} poll response, got {}",
+                response.channel
+            )));
+        }
+
+        Ok(response
+            .payload
+            .iter()
+            .copied()
+            .take_while(|byte| *byte != 0)
+            .filter_map(|byte| byte.checked_sub(1))
+            .collect())
+    }
+
+    pub async fn poll_status(&self) -> Result<Vec<u8>, ScsPactorError> {
+        let response = self.poll_channel(STATUS_CHANNEL).await?;
+        if response.channel != STATUS_CHANNEL {
+            return Err(ScsPactorError::Protocol(format!(
+                "expected channel {STATUS_CHANNEL} status response, got {}",
+                response.channel
+            )));
+        }
+        Ok(response.payload)
     }
 
     async fn send_frame(&self, channel: u8, payload: &[u8]) -> Result<(), ScsPactorError> {
@@ -249,6 +334,17 @@ async fn route_frame(
                 .await
                 .map_err(|_| ScsPactorError::Disconnected)?;
         }
+        STATUS_CHANNEL => {
+            if frame.payload.len() >= 3 {
+                let _ = event_tx
+                    .send(PactorLinkEvent::LinkQuality {
+                        speed_level: frame.payload[2],
+                        retries: 0,
+                    })
+                    .await;
+            }
+        }
+        EXTENDED_POLL_CHANNEL => {}
         other => {
             return Err(ScsPactorError::Protocol(format!(
                 "unknown hostmode channel {other}"
@@ -328,7 +424,7 @@ mod tests {
     use tokio::io::{duplex, AsyncReadExt};
 
     use super::*;
-    use crate::hostmode::decode_frame;
+    use crate::hostmode::{decode_frame, encode_repeat_request};
 
     fn test_config() -> UsbPactorConfig {
         UsbPactorConfig {
@@ -425,5 +521,98 @@ mod tests {
         assert_eq!(frame.channel, COMMAND_CHANNEL);
         assert_eq!(frame.code, b'D');
         assert_eq!(frame.payload, vec![0]);
+    }
+
+    #[tokio::test]
+    async fn usb_hostmode_transaction_retransmits_after_repeat_request() {
+        let (transport_side, mut modem_side) = duplex(4096);
+        let transport = UsbPactorTransport::from_stream(transport_side, test_config());
+
+        let modem = tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            let n = modem_side.read(&mut buf).await.unwrap();
+            let first = buf[..n].to_vec();
+            let frame = decode_frame(&first).unwrap();
+            assert_eq!(frame.channel, COMMAND_CHANNEL);
+            assert_eq!(frame.code, b'V');
+
+            modem_side
+                .write_all(&encode_repeat_request())
+                .await
+                .unwrap();
+
+            let n = modem_side.read(&mut buf).await.unwrap();
+            assert_eq!(&buf[..n], first.as_slice());
+
+            let response =
+                encode_frame(&HostmodeFrame::new(COMMAND_CHANNEL, b"OK".to_vec())).unwrap();
+            modem_side.write_all(&response).await.unwrap();
+        });
+
+        let response = transport
+            .hostmode_transaction(HostmodeFrame::with_code(COMMAND_CHANNEL, b'V', vec![0]))
+            .await
+            .unwrap();
+        assert_eq!(response.channel, COMMAND_CHANNEL);
+        assert_eq!(response.payload, b"OK");
+        modem.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn usb_poll_pending_channels_uses_extended_hostmode_channel() {
+        let (transport_side, mut modem_side) = duplex(4096);
+        let transport = UsbPactorTransport::from_stream(transport_side, test_config());
+
+        let modem = tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            let n = modem_side.read(&mut buf).await.unwrap();
+            let frame = decode_frame(&buf[..n]).unwrap();
+            assert_eq!(frame.channel, EXTENDED_POLL_CHANNEL);
+            assert_eq!(frame.code, b'G');
+            assert_eq!(frame.payload, vec![0]);
+
+            let response = encode_frame(&HostmodeFrame::with_code(
+                EXTENDED_POLL_CHANNEL,
+                1,
+                vec![3, 4, 0],
+            ))
+            .unwrap();
+            modem_side.write_all(&response).await.unwrap();
+        });
+
+        let channels = transport.poll_pending_channels().await.unwrap();
+        assert_eq!(channels, vec![2, 3]);
+        modem.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn usb_poll_status_returns_status_payload() {
+        let (transport_side, mut modem_side) = duplex(4096);
+        let transport = UsbPactorTransport::from_stream(transport_side, test_config());
+
+        let modem = tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            let n = modem_side.read(&mut buf).await.unwrap();
+            let frame = decode_frame(&buf[..n]).unwrap();
+            assert_eq!(frame.channel, STATUS_CHANNEL);
+            assert_eq!(frame.code, b'G');
+
+            let response =
+                encode_frame(&HostmodeFrame::with_code(STATUS_CHANNEL, 7, vec![1, 3, 5])).unwrap();
+            modem_side.write_all(&response).await.unwrap();
+        });
+
+        assert_eq!(transport.poll_status().await.unwrap(), vec![1, 3, 5]);
+        assert_eq!(
+            transport
+                .next_event(Some(Duration::from_millis(100)))
+                .await
+                .unwrap(),
+            PactorLinkEvent::LinkQuality {
+                speed_level: 5,
+                retries: 0
+            }
+        );
+        modem.await.unwrap();
     }
 }


### PR DESCRIPTION
  ## Summary

  Hardens the SCS PACTOR USB Hostmode implementation against the SCS CRC Hostmode packet format.

  ## Changes

  - Replace temporary Hostmode framing with CRC Hostmode-style packets.
  - Use `0xAA 0xAA` sync headers.
  - Add WA8DED-style channel, code, length-minus-one, payload, and CRC fields.
  - Add byte stuffing and de-stuffing for `0xAA`.
  - Detect repeat-request packets: `0xAA 0xAA 0xAA 0x55`.
  - Map USB Hostmode commands to Hostmode command codes:
    - `MYCALL` -> `I`
    - `CONNECT` -> `C`
    - `DISCONNECT` -> `D`
  - Add a master-side Hostmode transaction helper with retransmit on repeat request.
  - Add helpers for polling channel `255` and status channel `254`.
  - Add mock-stream tests for framing, command mapping, repeat request, and polling behavior.

  ## Verification

  - `cargo test -p scs_pactor`