### PR TITLE
feat: add PACTOR USB transport and simulator integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "log",
  "rand 0.9.1",
  "rpc",
+ "scs_pactor",
  "serde",
  "tokio",
  "wincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "rand 0.9.1",
  "rand_distr",
  "reed-solomon-erasure",
+ "scs_pactor",
  "serde",
  "thiserror 2.0.18",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ cargo run --bin node-api-radio-proto
 - The explorer API will be available at http://localhost:3001
 - See [Explorer API Spec](docs/rpc_spec.md) for endpoints
 
+To run the same radio-proto message path through the PACTOR simulator instead
+of the raw simulated radio transport:
+
+```bash
+cargo run --bin node-api-radio-proto -- --pactor
+```
+
 ### Repo Overview
 
 - `bunker_coin_core`: Shared types (hashes, blocks, transactions)
@@ -64,4 +71,4 @@ rustup update stable
 cargo check
 ```
 
-Nothing is stabilised yet, expect rapid iteration. 
+Nothing is stabilised yet, expect rapid iteration.

--- a/crates/radio/Cargo.toml
+++ b/crates/radio/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 bunker_coin_core = { workspace = true }
 bunkerglow = { workspace = true }
+scs_pactor = { path = "../scs_pactor" }
 
 tokio = { workspace = true }
 serde = { workspace = true }
@@ -24,4 +25,4 @@ wincode = { version = "0.2", features = ["derive"] }
 bytes = "1"
 
 [dev-dependencies]
-tokio-test = "0.4" 
+tokio-test = "0.4"

--- a/crates/radio/src/lib.rs
+++ b/crates/radio/src/lib.rs
@@ -6,11 +6,13 @@ use thiserror::Error;
 
 pub mod framing;
 pub mod network_core;
+pub mod pactor;
 pub mod scheduler;
 pub mod simulated;
 
 pub use framing::{RadioFrame, RadioFramer};
 pub use network_core::RadioNetworkCore;
+pub use pactor::PactorRadioNode;
 pub use scheduler::RadioScheduler;
 pub use simulated::SimulatedRadioNetwork;
 

--- a/crates/radio/src/pactor.rs
+++ b/crates/radio/src/pactor.rs
@@ -1,0 +1,128 @@
+use std::sync::Arc;
+
+use scs_pactor::PactorTransport;
+
+use crate::{Network, NetworkError, NetworkMessage};
+
+const DEFAULT_MAX_READ_LEN: usize = 4096;
+
+/// Radio-network adapter backed by any PACTOR transport.
+///
+/// PACTOR is already a connected point-to-point link, so the `to` address is
+/// used only as a guard against self-sends and empty destinations.
+pub struct PactorRadioNode {
+    callsign: String,
+    transport: Arc<dyn PactorTransport>,
+    max_read_len: usize,
+}
+
+impl PactorRadioNode {
+    pub fn new<T>(callsign: impl Into<String>, transport: T) -> Self
+    where
+        T: PactorTransport + 'static,
+    {
+        Self::from_shared(callsign, Arc::new(transport))
+    }
+
+    pub fn from_shared(callsign: impl Into<String>, transport: Arc<dyn PactorTransport>) -> Self {
+        Self {
+            callsign: callsign.into(),
+            transport,
+            max_read_len: DEFAULT_MAX_READ_LEN,
+        }
+    }
+
+    pub fn with_max_read_len(mut self, max_read_len: usize) -> Self {
+        self.max_read_len = max_read_len;
+        self
+    }
+}
+
+impl Network for PactorRadioNode {
+    type Address = String;
+
+    async fn send(
+        &self,
+        msg: &NetworkMessage,
+        to: impl AsRef<str> + Send,
+    ) -> Result<(), NetworkError> {
+        self.send_serialized(&msg.to_bytes(), to).await
+    }
+
+    async fn send_serialized(
+        &self,
+        bytes: &[u8],
+        to: impl AsRef<str> + Send,
+    ) -> Result<(), NetworkError> {
+        let to = to.as_ref().trim();
+        if to.is_empty() {
+            return Err(NetworkError::Unknown);
+        }
+        if to.eq_ignore_ascii_case(&self.callsign) {
+            return Ok(());
+        }
+
+        self.transport
+            .write_data(bytes)
+            .await
+            .map_err(|_| NetworkError::Unknown)
+    }
+
+    async fn receive(&self) -> Result<NetworkMessage, NetworkError> {
+        let payload = self
+            .transport
+            .read_data(self.max_read_len)
+            .await
+            .map_err(|_| NetworkError::Unknown)?;
+        NetworkMessage::from_bytes(&payload)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scs_pactor::{PactorTransport, SimulatedPactorConfig, SimulatedPactorPair};
+
+    #[tokio::test]
+    async fn pactor_radio_node_round_trips_network_messages() {
+        let config = SimulatedPactorConfig {
+            packet_loss: 0.0,
+            latency: std::time::Duration::ZERO,
+            latency_jitter: std::time::Duration::ZERO,
+            setup_delay: std::time::Duration::ZERO,
+            ..Default::default()
+        };
+        let (client_transport, node_transport) = SimulatedPactorPair::new(config);
+        client_transport.set_mycall("CLIENT").await.unwrap();
+        node_transport.set_mycall("NODE").await.unwrap();
+        client_transport.connect_peer("NODE").await.unwrap();
+
+        let client = PactorRadioNode::new("CLIENT", client_transport);
+        let node = PactorRadioNode::new("NODE", node_transport);
+        let expected = b"radio-over-pactor".to_vec();
+
+        client
+            .send(&NetworkMessage::Shred(expected.clone()), "NODE")
+            .await
+            .unwrap();
+
+        match node.receive().await.unwrap() {
+            NetworkMessage::Shred(actual) => assert_eq!(actual, expected),
+            other => panic!("expected Shred, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn pactor_radio_node_rejects_empty_destination() {
+        let config = SimulatedPactorConfig {
+            setup_delay: std::time::Duration::ZERO,
+            ..Default::default()
+        };
+        let (transport, _) = SimulatedPactorPair::new(config);
+        let node = PactorRadioNode::new("CLIENT", transport);
+
+        let result = node.send(&NetworkMessage::Ping, "").await;
+
+        assert!(result.is_err());
+    }
+}

--- a/crates/scs_pactor/README.md
+++ b/crates/scs_pactor/README.md
@@ -4,8 +4,9 @@ This crate provides transport implementations for SCS PACTOR-style links.
 
 ## USB Serial Smoke Test
 
-The USB transport opens a CDC-ACM serial device with 115200 baud, 8 data bits,
-no parity, 1 stop bit, and no flow control by default.
+The USB transport opens an SCS PACTOR modem such as a DR-7800, P4dragon, or
+PTC-IIIusb as a CDC-ACM serial device. Defaults are 115200 baud, 8 data bits,
+no parity, 1 stop bit, and no flow control.
 
 Example device paths:
 
@@ -13,7 +14,15 @@ Example device paths:
 - Linux: `/dev/ttyACM0` or `/dev/ttyUSB0`
 - Windows: `COM3`, `COM4`, or the assigned modem COM port shown in Device Manager
 
-Minimal usage:
+Before running against hardware:
+
+1. Connect the modem over USB and confirm the serial port path.
+2. Put the HF rig on the intended frequency; this crate does not control CAT,
+   tuning, or the auto-tuner.
+3. Choose your station callsign for `MYCALL`.
+4. Choose a known reachable PACTOR node callsign for `connect_peer`.
+
+Minimal smoke-test flow:
 
 ```rust
 use scs_pactor::{PactorTransport, UsbPactorConfig, UsbPactorTransport};
@@ -21,12 +30,13 @@ use scs_pactor::{PactorTransport, UsbPactorConfig, UsbPactorTransport};
 # async fn smoke() -> Result<(), scs_pactor::ScsPactorError> {
 let modem = UsbPactorTransport::connect(UsbPactorConfig::new("/dev/ttyACM0")).await?;
 modem.set_mycall("N0CALL").await?;
-modem.connect_peer("REMOTE").await?;
+modem.connect_peer("KNOWNNODE").await?;
 modem.write_data(b"hello").await?;
 modem.disconnect().await?;
 # Ok(())
 # }
 ```
 
-Before running against hardware, put the radio on the intended frequency and
-confirm the modem is visible as a serial device.
+Expected result: `connect_peer` returns after the modem reports
+`CONNECTED KNOWNNODE`; `next_event` can be used to observe `CONNECTED`,
+`DISCONNECTED`, `BUSY`, `QUEUED`, `LINK FAILURE`, and `LINK QUALITY` events.

--- a/crates/scs_pactor/src/lib.rs
+++ b/crates/scs_pactor/src/lib.rs
@@ -47,6 +47,7 @@ pub enum PactorLinkStatus {
     Disconnected,
     LinkFailure,
     Busy,
+    Queued,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/scs_pactor/src/lib.rs
+++ b/crates/scs_pactor/src/lib.rs
@@ -9,7 +9,8 @@ use async_trait::async_trait;
 use thiserror::Error;
 
 pub use simulator::{
-    PactorSpeed, SimulatedPactorConfig, SimulatedPactorPair, SimulatedPactorTransport,
+    FadeWindow, PactorSpeed, SimulatedPactorConfig, SimulatedPactorPair, SimulatedPactorStats,
+    SimulatedPactorTransport,
 };
 pub use tcp::{ScsPactorClient, ScsPactorConfig};
 pub use usb::{UsbPactorConfig, UsbPactorTransport};

--- a/crates/scs_pactor/src/simulator.rs
+++ b/crates/scs_pactor/src/simulator.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -36,6 +37,36 @@ impl PactorSpeed {
     }
 }
 
+impl PactorSpeed {
+    fn downshift(self) -> Self {
+        match self {
+            Self::P4 => Self::P3,
+            Self::P3 => Self::P2,
+            Self::P2 => Self::P1,
+            Self::P1 => Self::P1,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FadeWindow {
+    pub starts_after: Duration,
+    pub duration: Duration,
+}
+
+impl FadeWindow {
+    pub fn new(starts_after: Duration, duration: Duration) -> Self {
+        Self {
+            starts_after,
+            duration,
+        }
+    }
+
+    fn contains(self, elapsed: Duration) -> bool {
+        elapsed >= self.starts_after && elapsed < self.starts_after + self.duration
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct SimulatedPactorConfig {
     pub speed: PactorSpeed,
@@ -44,6 +75,9 @@ pub struct SimulatedPactorConfig {
     pub latency_jitter: Duration,
     pub setup_delay: Duration,
     pub max_retries: u32,
+    pub downshift_after_retries: u32,
+    pub forced_initial_losses: u32,
+    pub fade_windows: Vec<FadeWindow>,
     pub read_timeout: Option<Duration>,
 }
 
@@ -56,7 +90,49 @@ impl Default for SimulatedPactorConfig {
             latency_jitter: Duration::from_millis(50),
             setup_delay: Duration::from_secs(2),
             max_retries: 8,
+            downshift_after_retries: 2,
+            forced_initial_losses: 0,
+            fade_windows: Vec::new(),
             read_timeout: Some(Duration::from_secs(10)),
+        }
+    }
+}
+
+impl SimulatedPactorConfig {
+    pub fn good_link() -> Self {
+        Self {
+            speed: PactorSpeed::P4,
+            packet_loss: 0.02,
+            latency: Duration::from_millis(150),
+            latency_jitter: Duration::from_millis(25),
+            setup_delay: Duration::from_secs(2),
+            max_retries: 8,
+            downshift_after_retries: 2,
+            forced_initial_losses: 0,
+            fade_windows: Vec::new(),
+            read_timeout: Some(Duration::from_secs(10)),
+        }
+    }
+
+    pub fn marginal_link() -> Self {
+        Self {
+            speed: PactorSpeed::P3,
+            packet_loss: 0.30,
+            latency: Duration::from_millis(600),
+            latency_jitter: Duration::from_millis(250),
+            setup_delay: Duration::from_secs(4),
+            max_retries: 12,
+            downshift_after_retries: 1,
+            forced_initial_losses: 0,
+            fade_windows: Vec::new(),
+            read_timeout: Some(Duration::from_secs(20)),
+        }
+    }
+
+    pub fn fading_link(fade_windows: Vec<FadeWindow>) -> Self {
+        Self {
+            fade_windows,
+            ..Self::marginal_link()
         }
     }
 }
@@ -95,11 +171,43 @@ impl Endpoint {
     }
 }
 
+#[derive(Debug, Default)]
+struct SharedStats {
+    frames_attempted: AtomicU64,
+    frames_delivered: AtomicU64,
+    frames_lost: AtomicU64,
+    retransmissions: AtomicU64,
+    bytes_delivered: AtomicU64,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SimulatedPactorStats {
+    pub frames_attempted: u64,
+    pub frames_delivered: u64,
+    pub frames_lost: u64,
+    pub retransmissions: u64,
+    pub bytes_delivered: u64,
+}
+
+impl SharedStats {
+    fn snapshot(&self) -> SimulatedPactorStats {
+        SimulatedPactorStats {
+            frames_attempted: self.frames_attempted.load(Ordering::Relaxed),
+            frames_delivered: self.frames_delivered.load(Ordering::Relaxed),
+            frames_lost: self.frames_lost.load(Ordering::Relaxed),
+            retransmissions: self.retransmissions.load(Ordering::Relaxed),
+            bytes_delivered: self.bytes_delivered.load(Ordering::Relaxed),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct SimulatedPactorTransport {
     local: Arc<Endpoint>,
     remote: Arc<Endpoint>,
     config: SimulatedPactorConfig,
+    stats: Arc<SharedStats>,
+    started_at: tokio::time::Instant,
 }
 
 pub struct SimulatedPactorPair;
@@ -110,18 +218,117 @@ impl SimulatedPactorPair {
     ) -> (SimulatedPactorTransport, SimulatedPactorTransport) {
         let a = Endpoint::new();
         let b = Endpoint::new();
+        let stats = Arc::new(SharedStats::default());
+        let started_at = tokio::time::Instant::now();
         (
             SimulatedPactorTransport {
                 local: a.clone(),
                 remote: b.clone(),
                 config: config.clone(),
+                stats: stats.clone(),
+                started_at,
             },
             SimulatedPactorTransport {
                 local: b,
                 remote: a,
                 config,
+                stats,
+                started_at,
             },
         )
+    }
+}
+
+impl SimulatedPactorTransport {
+    pub fn stats(&self) -> SimulatedPactorStats {
+        self.stats.snapshot()
+    }
+
+    fn in_fade(&self) -> bool {
+        let elapsed = self.started_at.elapsed();
+        self.config
+            .fade_windows
+            .iter()
+            .any(|window| window.contains(elapsed))
+    }
+
+    pub async fn send_command(&self, line: &str) -> Result<(), ScsPactorError> {
+        let trimmed = line.trim();
+        let mut parts = trimmed.splitn(2, char::is_whitespace);
+        let command = parts.next().unwrap_or_default();
+        let payload = parts.next().unwrap_or_default().trim();
+
+        match command {
+            "I" | "MYCALL" => {
+                self.set_mycall(payload).await?;
+                self.emit_status_line("OK").await;
+                Ok(())
+            }
+            "C" | "CONNECT" => match self.connect_peer(payload).await {
+                Ok(()) => Ok(()),
+                Err(err) => {
+                    self.emit_status_line("LINK FAILURE").await;
+                    Err(err)
+                }
+            },
+            "D" | "DISCONNECT" => {
+                self.disconnect().await?;
+                self.emit_status_line("DISCONNECTED").await;
+                Ok(())
+            }
+            "G" => {
+                self.emit_status_line("255,0").await;
+                Ok(())
+            }
+            _ => Err(ScsPactorError::Protocol(format!(
+                "unsupported simulator command {command}"
+            ))),
+        }
+    }
+
+    pub async fn read_status_line(&self) -> Result<String, ScsPactorError> {
+        loop {
+            match self.next_event(self.config.read_timeout).await? {
+                PactorLinkEvent::Status(PactorLinkStatus::Connected { remote_call }) => {
+                    return Ok(format!("CONNECTED {remote_call}"));
+                }
+                PactorLinkEvent::Status(PactorLinkStatus::Connecting { remote_call }) => {
+                    return Ok(format!("CONNECTING {remote_call}"));
+                }
+                PactorLinkEvent::Status(PactorLinkStatus::Disconnected) => {
+                    return Ok("DISCONNECTED".to_owned());
+                }
+                PactorLinkEvent::Status(PactorLinkStatus::LinkFailure) => {
+                    return Ok("LINK FAILURE".to_owned());
+                }
+                PactorLinkEvent::Status(PactorLinkStatus::Busy) => return Ok("BUSY".to_owned()),
+                PactorLinkEvent::Status(PactorLinkStatus::Idle) => return Ok("IDLE".to_owned()),
+                PactorLinkEvent::LinkQuality {
+                    speed_level,
+                    retries,
+                } => {
+                    return Ok(format!(
+                        "LINK QUALITY SPEED={speed_level} RETRIES={retries}"
+                    ))
+                }
+            }
+        }
+    }
+
+    async fn emit_status_line(&self, line: &str) {
+        let event = match line {
+            "OK" => PactorLinkEvent::Status(PactorLinkStatus::Idle),
+            "DISCONNECTED" => PactorLinkEvent::Status(PactorLinkStatus::Disconnected),
+            "LINK FAILURE" => PactorLinkEvent::Status(PactorLinkStatus::LinkFailure),
+            "BUSY" => PactorLinkEvent::Status(PactorLinkStatus::Busy),
+            line if line.starts_with("CONNECTED ") => {
+                PactorLinkEvent::Status(PactorLinkStatus::Connected {
+                    remote_call: line["CONNECTED ".len()..].trim().to_owned(),
+                })
+            }
+            _ => PactorLinkEvent::Status(PactorLinkStatus::Idle),
+        };
+        let _ = self.local.event_tx.send(event).await;
     }
 }
 
@@ -178,10 +385,11 @@ impl PactorTransport for SimulatedPactorTransport {
         }
 
         let mut retries = 0;
+        let mut speed = self.config.speed;
         loop {
-            let transmit_time = Duration::from_secs_f64(
-                (data.len() * 8) as f64 / self.config.speed.raw_bps() as f64,
-            );
+            self.stats.frames_attempted.fetch_add(1, Ordering::Relaxed);
+            let transmit_time =
+                Duration::from_secs_f64((data.len() * 8) as f64 / speed.raw_bps() as f64);
             let jitter = if self.config.latency_jitter.is_zero() {
                 Duration::ZERO
             } else {
@@ -190,17 +398,25 @@ impl PactorTransport for SimulatedPactorTransport {
             };
             sleep(transmit_time + self.config.latency + jitter).await;
 
-            if rand::rng().random::<f32>() >= self.config.packet_loss {
+            let forced_loss = retries < self.config.forced_initial_losses;
+            if !forced_loss
+                && !self.in_fade()
+                && rand::rng().random::<f32>() >= self.config.packet_loss
+            {
                 self.remote
                     .data_tx
                     .send(data.to_vec())
                     .await
                     .map_err(|_| ScsPactorError::Disconnected)?;
+                self.stats.frames_delivered.fetch_add(1, Ordering::Relaxed);
+                self.stats
+                    .bytes_delivered
+                    .fetch_add(data.len() as u64, Ordering::Relaxed);
                 let _ = self
                     .local
                     .event_tx
                     .send(PactorLinkEvent::LinkQuality {
-                        speed_level: self.config.speed.level(),
+                        speed_level: speed.level(),
                         retries,
                     })
                     .await;
@@ -208,6 +424,11 @@ impl PactorTransport for SimulatedPactorTransport {
             }
 
             retries += 1;
+            self.stats.frames_lost.fetch_add(1, Ordering::Relaxed);
+            self.stats.retransmissions.fetch_add(1, Ordering::Relaxed);
+            if retries >= self.config.downshift_after_retries {
+                speed = speed.downshift();
+            }
             if retries > self.config.max_retries {
                 let _ = self
                     .local
@@ -319,5 +540,190 @@ mod tests {
 
         let err = client.write_data(b"lost").await.unwrap_err();
         assert!(matches!(err, ScsPactorError::Disconnected));
+        let stats = client.stats();
+        assert_eq!(stats.frames_delivered, 0);
+        assert_eq!(stats.frames_lost, 3);
+        assert_eq!(stats.retransmissions, 3);
+    }
+
+    #[tokio::test]
+    async fn simulator_profiles_expose_expected_link_shapes() {
+        let good = SimulatedPactorConfig::good_link();
+        assert_eq!(good.speed, PactorSpeed::P4);
+        assert!(good.packet_loss < 0.05);
+
+        let marginal = SimulatedPactorConfig::marginal_link();
+        assert_eq!(marginal.speed, PactorSpeed::P3);
+        assert!(marginal.packet_loss > good.packet_loss);
+
+        let fading = SimulatedPactorConfig::fading_link(vec![FadeWindow::new(
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+        )]);
+        assert_eq!(fading.fade_windows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn simulator_fade_window_drops_until_retry_budget_exhausts() {
+        let config = SimulatedPactorConfig {
+            packet_loss: 0.0,
+            latency: Duration::ZERO,
+            latency_jitter: Duration::ZERO,
+            setup_delay: Duration::ZERO,
+            max_retries: 1,
+            fade_windows: vec![FadeWindow::new(Duration::ZERO, Duration::from_secs(10))],
+            ..Default::default()
+        };
+        let (client, node) = SimulatedPactorPair::new(config);
+        client.set_mycall("CLIENT").await.unwrap();
+        node.set_mycall("NODE").await.unwrap();
+        client.connect_peer("NODE").await.unwrap();
+
+        let err = client.write_data(b"fade").await.unwrap_err();
+        assert!(matches!(err, ScsPactorError::Disconnected));
+        let stats = client.stats();
+        assert_eq!(stats.frames_delivered, 0);
+        assert_eq!(stats.frames_lost, 2);
+    }
+
+    #[tokio::test]
+    async fn simulator_reports_downshifted_speed_after_retries() {
+        let config = SimulatedPactorConfig {
+            speed: PactorSpeed::P4,
+            packet_loss: 0.0,
+            latency: Duration::ZERO,
+            latency_jitter: Duration::ZERO,
+            setup_delay: Duration::ZERO,
+            max_retries: 4,
+            downshift_after_retries: 1,
+            forced_initial_losses: 1,
+            ..Default::default()
+        };
+        let (client, node) = SimulatedPactorPair::new(config);
+        client.set_mycall("CLIENT").await.unwrap();
+        node.set_mycall("NODE").await.unwrap();
+        client.connect_peer("NODE").await.unwrap();
+
+        client.write_data(b"hello").await.unwrap();
+        let event = client
+            .next_event(Some(Duration::from_millis(50)))
+            .await
+            .unwrap();
+        assert_eq!(
+            event,
+            PactorLinkEvent::Status(PactorLinkStatus::Connecting {
+                remote_call: "NODE".to_owned()
+            })
+        );
+        let event = client
+            .next_event(Some(Duration::from_millis(50)))
+            .await
+            .unwrap();
+        assert_eq!(
+            event,
+            PactorLinkEvent::Status(PactorLinkStatus::Connected {
+                remote_call: "NODE".to_owned()
+            })
+        );
+        let event = client
+            .next_event(Some(Duration::from_millis(50)))
+            .await
+            .unwrap();
+        assert_eq!(
+            event,
+            PactorLinkEvent::LinkQuality {
+                speed_level: PactorSpeed::P3.level(),
+                retries: 1
+            }
+        );
+        assert_eq!(node.read_data(1024).await.unwrap(), b"hello");
+    }
+
+    #[tokio::test]
+    async fn simulator_command_surface_matches_hostmode_commands() {
+        let config = SimulatedPactorConfig {
+            packet_loss: 0.0,
+            latency: Duration::ZERO,
+            latency_jitter: Duration::ZERO,
+            setup_delay: Duration::ZERO,
+            ..Default::default()
+        };
+        let (client, node) = SimulatedPactorPair::new(config);
+
+        client.send_command("I CLIENT").await.unwrap();
+        node.send_command("I NODE").await.unwrap();
+
+        client.send_command("C NODE").await.unwrap();
+        assert_eq!(client.read_status_line().await.unwrap(), "IDLE");
+        assert_eq!(client.read_status_line().await.unwrap(), "CONNECTING NODE");
+        assert_eq!(client.read_status_line().await.unwrap(), "CONNECTED NODE");
+
+        client.send_command("D").await.unwrap();
+        assert_eq!(client.read_status_line().await.unwrap(), "DISCONNECTED");
+    }
+
+    #[tokio::test]
+    async fn simulator_clean_link_has_no_retransmission_overhead() {
+        let config = SimulatedPactorConfig {
+            packet_loss: 0.0,
+            latency: Duration::ZERO,
+            latency_jitter: Duration::ZERO,
+            setup_delay: Duration::ZERO,
+            ..Default::default()
+        };
+        let (client, node) = SimulatedPactorPair::new(config);
+        client.set_mycall("CLIENT").await.unwrap();
+        node.set_mycall("NODE").await.unwrap();
+        client.connect_peer("NODE").await.unwrap();
+
+        client.write_data(&[0xAB; 128]).await.unwrap();
+        assert_eq!(node.read_data(1024).await.unwrap(), vec![0xAB; 128]);
+
+        let stats = client.stats();
+        assert_eq!(stats.frames_attempted, 1);
+        assert_eq!(stats.frames_delivered, 1);
+        assert_eq!(stats.frames_lost, 0);
+        assert_eq!(stats.retransmissions, 0);
+        assert_eq!(stats.bytes_delivered, 128);
+    }
+
+    #[tokio::test]
+    async fn simulator_loss_degrades_effective_delivery_efficiency() {
+        let clean = SimulatedPactorConfig {
+            packet_loss: 0.0,
+            latency: Duration::ZERO,
+            latency_jitter: Duration::ZERO,
+            setup_delay: Duration::ZERO,
+            ..Default::default()
+        };
+        let lossy = SimulatedPactorConfig {
+            packet_loss: 0.0,
+            latency: Duration::ZERO,
+            latency_jitter: Duration::ZERO,
+            setup_delay: Duration::ZERO,
+            forced_initial_losses: 2,
+            max_retries: 4,
+            ..Default::default()
+        };
+
+        let (clean_client, clean_node) = SimulatedPactorPair::new(clean);
+        clean_client.set_mycall("CLIENT").await.unwrap();
+        clean_node.set_mycall("NODE").await.unwrap();
+        clean_client.connect_peer("NODE").await.unwrap();
+        clean_client.write_data(&[0xCD; 64]).await.unwrap();
+
+        let (lossy_client, lossy_node) = SimulatedPactorPair::new(lossy);
+        lossy_client.set_mycall("CLIENT").await.unwrap();
+        lossy_node.set_mycall("NODE").await.unwrap();
+        lossy_client.connect_peer("NODE").await.unwrap();
+        lossy_client.write_data(&[0xCD; 64]).await.unwrap();
+
+        let clean_stats = clean_client.stats();
+        let lossy_stats = lossy_client.stats();
+        assert_eq!(clean_stats.frames_attempted, 1);
+        assert_eq!(lossy_stats.frames_attempted, 3);
+        assert_eq!(lossy_stats.frames_lost, 2);
+        assert_eq!(lossy_stats.retransmissions, 2);
+        assert_eq!(lossy_stats.bytes_delivered, clean_stats.bytes_delivered);
     }
 }

--- a/crates/scs_pactor/src/simulator.rs
+++ b/crates/scs_pactor/src/simulator.rs
@@ -302,6 +302,9 @@ impl SimulatedPactorTransport {
                     return Ok("LINK FAILURE".to_owned());
                 }
                 PactorLinkEvent::Status(PactorLinkStatus::Busy) => return Ok("BUSY".to_owned()),
+                PactorLinkEvent::Status(PactorLinkStatus::Queued) => {
+                    return Ok("QUEUED".to_owned());
+                }
                 PactorLinkEvent::Status(PactorLinkStatus::Idle) => return Ok("IDLE".to_owned()),
                 PactorLinkEvent::LinkQuality {
                     speed_level,
@@ -321,6 +324,7 @@ impl SimulatedPactorTransport {
             "DISCONNECTED" => PactorLinkEvent::Status(PactorLinkStatus::Disconnected),
             "LINK FAILURE" => PactorLinkEvent::Status(PactorLinkStatus::LinkFailure),
             "BUSY" => PactorLinkEvent::Status(PactorLinkStatus::Busy),
+            "QUEUED" => PactorLinkEvent::Status(PactorLinkStatus::Queued),
             line if line.starts_with("CONNECTED ") => {
                 PactorLinkEvent::Status(PactorLinkStatus::Connected {
                     remote_call: line["CONNECTED ".len()..].trim().to_owned(),
@@ -657,6 +661,9 @@ mod tests {
         assert_eq!(client.read_status_line().await.unwrap(), "IDLE");
         assert_eq!(client.read_status_line().await.unwrap(), "CONNECTING NODE");
         assert_eq!(client.read_status_line().await.unwrap(), "CONNECTED NODE");
+
+        client.emit_status_line("QUEUED").await;
+        assert_eq!(client.read_status_line().await.unwrap(), "QUEUED");
 
         client.send_command("D").await.unwrap();
         assert_eq!(client.read_status_line().await.unwrap(), "DISCONNECTED");

--- a/crates/scs_pactor/src/tcp.rs
+++ b/crates/scs_pactor/src/tcp.rs
@@ -113,6 +113,9 @@ impl ScsPactorClient {
         if line.starts_with("BUSY") {
             return Ok(PactorLinkEvent::Status(PactorLinkStatus::Busy));
         }
+        if line.starts_with("QUEUED") {
+            return Ok(PactorLinkEvent::Status(PactorLinkStatus::Queued));
+        }
         if line.starts_with("LINK FAILURE") || line.starts_with("FAIL") || line.starts_with("NO ") {
             return Ok(PactorLinkEvent::Status(PactorLinkStatus::LinkFailure));
         }
@@ -148,6 +151,7 @@ impl ScsPactorClient {
                 PactorLinkEvent::Status(PactorLinkStatus::Busy) => {
                     return Err(ScsPactorError::Busy)
                 }
+                PactorLinkEvent::Status(PactorLinkStatus::Queued) => {}
                 PactorLinkEvent::Status(
                     PactorLinkStatus::Disconnected | PactorLinkStatus::LinkFailure,
                 ) => {
@@ -263,5 +267,11 @@ mod tests {
                 retries: 2
             }
         );
+    }
+
+    #[test]
+    fn parse_queued_status() {
+        let event = ScsPactorClient::parse_status_line("QUEUED").unwrap();
+        assert_eq!(event, PactorLinkEvent::Status(PactorLinkStatus::Queued));
     }
 }

--- a/crates/scs_pactor/src/usb.rs
+++ b/crates/scs_pactor/src/usb.rs
@@ -295,6 +295,9 @@ impl UsbPactorTransport {
         if line.starts_with("BUSY") {
             return Ok(PactorLinkEvent::Status(PactorLinkStatus::Busy));
         }
+        if line.starts_with("QUEUED") {
+            return Ok(PactorLinkEvent::Status(PactorLinkStatus::Queued));
+        }
         if line.starts_with("LINK FAILURE") || line.starts_with("FAIL") || line.starts_with("NO ") {
             return Ok(PactorLinkEvent::Status(PactorLinkStatus::LinkFailure));
         }
@@ -384,6 +387,7 @@ impl PactorTransport for UsbPactorTransport {
                 PactorLinkEvent::Status(PactorLinkStatus::Busy) => {
                     return Err(ScsPactorError::Busy)
                 }
+                PactorLinkEvent::Status(PactorLinkStatus::Queued) => {}
                 PactorLinkEvent::Status(
                     PactorLinkStatus::Disconnected | PactorLinkStatus::LinkFailure,
                 ) => return Err(ScsPactorError::Io(std::io::Error::other(line))),
@@ -519,6 +523,72 @@ mod tests {
 
         transport.connect_peer("NODE").await.unwrap();
         modem.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn usb_transport_connect_peer_reports_busy_status() {
+        let (transport_side, mut modem_side) = duplex(2048);
+        let transport = UsbPactorTransport::from_stream(transport_side, test_config());
+
+        let modem = tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            let n = modem_side.read(&mut buf).await.unwrap();
+            let frame = decode_frame(&buf[..n]).unwrap();
+            assert_eq!(frame.channel, COMMAND_CHANNEL);
+            assert_eq!(frame.code, b'C');
+            assert_eq!(frame.payload, b"NODE");
+
+            let busy =
+                encode_frame(&HostmodeFrame::new(COMMAND_CHANNEL, b"BUSY".to_vec())).unwrap();
+            modem_side.write_all(&busy).await.unwrap();
+        });
+
+        let err = transport.connect_peer("NODE").await.unwrap_err();
+        assert!(matches!(err, ScsPactorError::Busy));
+        modem.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn usb_transport_connect_peer_waits_through_queued_status() {
+        let (transport_side, mut modem_side) = duplex(4096);
+        let transport = UsbPactorTransport::from_stream(transport_side, test_config());
+
+        let modem = tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            let n = modem_side.read(&mut buf).await.unwrap();
+            let frame = decode_frame(&buf[..n]).unwrap();
+            assert_eq!(frame.channel, COMMAND_CHANNEL);
+            assert_eq!(frame.code, b'C');
+            assert_eq!(frame.payload, b"NODE");
+
+            let queued =
+                encode_frame(&HostmodeFrame::new(COMMAND_CHANNEL, b"QUEUED".to_vec())).unwrap();
+            let connected = encode_frame(&HostmodeFrame::new(
+                COMMAND_CHANNEL,
+                b"CONNECTED NODE".to_vec(),
+            ))
+            .unwrap();
+            modem_side.write_all(&queued).await.unwrap();
+            modem_side.write_all(&connected).await.unwrap();
+        });
+
+        transport.connect_peer("NODE").await.unwrap();
+        modem.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn usb_transport_reports_disconnect_when_device_unplugs() {
+        let (transport_side, modem_side) = duplex(1024);
+        let transport = UsbPactorTransport::from_stream(transport_side, test_config());
+        drop(modem_side);
+
+        assert_eq!(
+            transport
+                .next_event(Some(Duration::from_millis(100)))
+                .await
+                .unwrap(),
+            PactorLinkEvent::Status(PactorLinkStatus::Disconnected)
+        );
     }
 
     #[tokio::test]

--- a/crates/sim/Cargo.toml
+++ b/crates/sim/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/bin/radio_sim.rs"
 bunker_coin_core = { workspace = true }
 bunker_coin_radio = { workspace = true }
 bunkerglow = { workspace = true }
+scs_pactor = { path = "../scs_pactor" }
 
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/sim/src/bin/node-api-radio-proto.rs
+++ b/crates/sim/src/bin/node-api-radio-proto.rs
@@ -11,6 +11,11 @@ use tokio::task;
 async fn main() {
     env_logger::init();
 
+    if std::env::args().any(|arg| arg == "--pactor") {
+        run_pactor_radio_proto_demo().await;
+        return;
+    }
+
     let data_dir = std::env::temp_dir().join(format!(
         "bunker-coin-node-api-radio-proto-{}",
         std::process::id()
@@ -81,4 +86,73 @@ async fn main() {
 
     log::info!("Simulation completed, shutting down API server");
     api_handle.await.unwrap();
+}
+
+async fn run_pactor_radio_proto_demo() {
+    let mut config = scs_pactor::SimulatedPactorConfig::good_link();
+    config.latency = std::time::Duration::from_millis(100);
+    config.latency_jitter = std::time::Duration::from_millis(25);
+    config.setup_delay = std::time::Duration::from_millis(250);
+
+    let result = scenarios::pactor_radio_proto_demo(config)
+        .await
+        .expect("run PACTOR radio-proto simulation");
+
+    println!("PACTOR radio-proto demo complete");
+    println!("received messages: {:?}", result.received_messages);
+    println!("frames attempted: {}", result.frames_attempted);
+    println!("frames lost: {}", result.frames_lost);
+    println!("retransmissions: {}", result.retransmissions);
+    println!("bytes delivered: {}", result.bytes_delivered);
+
+    let comparison = scenarios::pactor_radio_proto_degradation_demo()
+        .await
+        .expect("run PACTOR ARQ degradation simulation");
+    println!();
+    println!("clean vs degraded PACTOR radio-proto:");
+    println!(
+        "clean: attempts={}, lost={}, retransmissions={}, bytes={}",
+        comparison.clean.frames_attempted,
+        comparison.clean.frames_lost,
+        comparison.clean.retransmissions,
+        comparison.clean.bytes_delivered
+    );
+    println!(
+        "degraded: attempts={}, lost={}, retransmissions={}, bytes={}",
+        comparison.degraded.frames_attempted,
+        comparison.degraded.frames_lost,
+        comparison.degraded.retransmissions,
+        comparison.degraded.bytes_delivered
+    );
+
+    println!();
+    println!("PACTOR speed report:");
+    for sample in scenarios::pactor_throughput_report() {
+        println!(
+            "PT-{}: raw={} bps, clean={:.0} bps ({:.1}% error), degraded ARQ={:.0} bps",
+            sample.speed_level,
+            sample.raw_bps,
+            sample.clean_effective_bps,
+            sample.clean_error_pct,
+            sample.degraded_effective_bps
+        );
+    }
+
+    println!();
+    println!("Measured PACTOR simulator throughput:");
+    let measured = scenarios::pactor_measured_throughput_report()
+        .await
+        .expect("measure PACTOR simulator throughput");
+    for sample in measured {
+        println!(
+            "PT-{}: payload={} bytes, raw={} bps, clean={:.0} bps ({:.1}% error), degraded={:.0} bps ({} retransmissions)",
+            sample.speed_level,
+            sample.payload_bytes,
+            sample.raw_bps,
+            sample.clean_effective_bps,
+            sample.clean_error_pct,
+            sample.degraded_effective_bps,
+            sample.degraded_retransmissions
+        );
+    }
 }

--- a/crates/sim/src/bin/pactor_radio_proto.rs
+++ b/crates/sim/src/bin/pactor_radio_proto.rs
@@ -1,0 +1,25 @@
+//! PACTOR-backed radio protocol demo.
+
+use bunker_coin_sim::scenarios;
+use scs_pactor::SimulatedPactorConfig;
+
+#[tokio::main]
+async fn main() -> Result<(), scs_pactor::ScsPactorError> {
+    env_logger::init();
+
+    let mut config = SimulatedPactorConfig::good_link();
+    config.latency = std::time::Duration::from_millis(100);
+    config.latency_jitter = std::time::Duration::from_millis(25);
+    config.setup_delay = std::time::Duration::from_millis(250);
+
+    let result = scenarios::pactor_radio_proto_demo(config).await?;
+
+    println!("PACTOR radio-proto demo complete");
+    println!("received: {:?}", result.received_message);
+    println!("frames attempted: {}", result.frames_attempted);
+    println!("frames lost: {}", result.frames_lost);
+    println!("retransmissions: {}", result.retransmissions);
+    println!("bytes delivered: {}", result.bytes_delivered);
+
+    Ok(())
+}

--- a/crates/sim/src/bin/pactor_radio_proto.rs
+++ b/crates/sim/src/bin/pactor_radio_proto.rs
@@ -15,11 +15,29 @@ async fn main() -> Result<(), scs_pactor::ScsPactorError> {
     let result = scenarios::pactor_radio_proto_demo(config).await?;
 
     println!("PACTOR radio-proto demo complete");
-    println!("received: {:?}", result.received_message);
+    println!("received messages: {:?}", result.received_messages);
     println!("frames attempted: {}", result.frames_attempted);
     println!("frames lost: {}", result.frames_lost);
     println!("retransmissions: {}", result.retransmissions);
     println!("bytes delivered: {}", result.bytes_delivered);
+
+    let comparison = scenarios::pactor_radio_proto_degradation_demo().await?;
+    println!();
+    println!("clean vs degraded PACTOR radio-proto:");
+    println!(
+        "clean: attempts={}, lost={}, retransmissions={}, bytes={}",
+        comparison.clean.frames_attempted,
+        comparison.clean.frames_lost,
+        comparison.clean.retransmissions,
+        comparison.clean.bytes_delivered
+    );
+    println!(
+        "degraded: attempts={}, lost={}, retransmissions={}, bytes={}",
+        comparison.degraded.frames_attempted,
+        comparison.degraded.frames_lost,
+        comparison.degraded.retransmissions,
+        comparison.degraded.bytes_delivered
+    );
 
     Ok(())
 }

--- a/crates/sim/src/bin/pactor_radio_proto.rs
+++ b/crates/sim/src/bin/pactor_radio_proto.rs
@@ -38,6 +38,32 @@ async fn main() -> Result<(), scs_pactor::ScsPactorError> {
         comparison.degraded.retransmissions,
         comparison.degraded.bytes_delivered
     );
+    println!();
+    println!("PACTOR speed report:");
+    for sample in scenarios::pactor_throughput_report() {
+        println!(
+            "PT-{}: raw={} bps, clean={:.0} bps ({:.1}% error), degraded ARQ={:.0} bps",
+            sample.speed_level,
+            sample.raw_bps,
+            sample.clean_effective_bps,
+            sample.clean_error_pct,
+            sample.degraded_effective_bps
+        );
+    }
+    println!();
+    println!("Measured PACTOR simulator throughput:");
+    for sample in scenarios::pactor_measured_throughput_report().await? {
+        println!(
+            "PT-{}: payload={} bytes, raw={} bps, clean={:.0} bps ({:.1}% error), degraded={:.0} bps ({} retransmissions)",
+            sample.speed_level,
+            sample.payload_bytes,
+            sample.raw_bps,
+            sample.clean_effective_bps,
+            sample.clean_error_pct,
+            sample.degraded_effective_bps,
+            sample.degraded_retransmissions
+        );
+    }
 
     Ok(())
 }

--- a/crates/sim/src/scenarios.rs
+++ b/crates/sim/src/scenarios.rs
@@ -2,7 +2,7 @@
 
 use bincode;
 use bunker_coin_radio::{
-    Network as RadioNetwork, NetworkMessage, RadioConfig, SimulatedRadioNetwork,
+    Network as RadioNetwork, NetworkMessage, PactorRadioNode, RadioConfig, SimulatedRadioNetwork,
 };
 use bunkerglow::crypto::merkle::{DoubleMerkleRoot, MerkleRoot};
 use bunkerglow::crypto::signature::SecretKey;
@@ -27,7 +27,7 @@ pub async fn pactor_radio_proto_demo(
 ) -> Result<PactorRadioProtoResult, scs_pactor::ScsPactorError> {
     use bunker_coin_radio::Network;
 
-    let (client, node) = PactorRadioNetworkPair::new(config).await?;
+    let (client, node, stats_source) = PactorRadioNetworkPair::new(config).await?;
 
     let outbound = vec![
         NetworkMessage::Ping,
@@ -50,7 +50,7 @@ pub async fn pactor_radio_proto_demo(
                 .map_err(|e| scs_pactor::ScsPactorError::Protocol(e.to_string()))?,
         );
     }
-    let stats = client.stats();
+    let stats = stats_source.stats();
 
     Ok(PactorRadioProtoResult {
         received_messages,
@@ -66,81 +66,26 @@ struct PactorRadioNetworkPair;
 impl PactorRadioNetworkPair {
     async fn new(
         config: scs_pactor::SimulatedPactorConfig,
-    ) -> Result<(PactorRadioNode, PactorRadioNode), scs_pactor::ScsPactorError> {
+    ) -> Result<
+        (
+            PactorRadioNode,
+            PactorRadioNode,
+            scs_pactor::SimulatedPactorTransport,
+        ),
+        scs_pactor::ScsPactorError,
+    > {
         use scs_pactor::{PactorTransport, SimulatedPactorPair};
 
-        let (client, node) = SimulatedPactorPair::new(config);
-        client.set_mycall("CLIENT").await?;
-        node.set_mycall("NODE").await?;
-        client.connect_peer("NODE").await?;
+        let (client_transport, node_transport) = SimulatedPactorPair::new(config);
+        client_transport.set_mycall("CLIENT").await?;
+        node_transport.set_mycall("NODE").await?;
+        client_transport.connect_peer("NODE").await?;
 
         Ok((
-            PactorRadioNode {
-                callsign: "CLIENT",
-                transport: client,
-            },
-            PactorRadioNode {
-                callsign: "NODE",
-                transport: node,
-            },
+            PactorRadioNode::new("CLIENT", client_transport.clone()),
+            PactorRadioNode::new("NODE", node_transport),
+            client_transport,
         ))
-    }
-}
-
-struct PactorRadioNode {
-    callsign: &'static str,
-    transport: scs_pactor::SimulatedPactorTransport,
-}
-
-impl PactorRadioNode {
-    fn stats(&self) -> scs_pactor::SimulatedPactorStats {
-        self.transport.stats()
-    }
-}
-
-impl bunker_coin_radio::Network for PactorRadioNode {
-    type Address = String;
-
-    async fn send(
-        &self,
-        msg: &NetworkMessage,
-        to: impl AsRef<str> + Send,
-    ) -> Result<(), bunker_coin_radio::NetworkError> {
-        self.send_serialized(&msg.to_bytes(), to).await
-    }
-
-    async fn send_serialized(
-        &self,
-        bytes: &[u8],
-        to: impl AsRef<str> + Send,
-    ) -> Result<(), bunker_coin_radio::NetworkError> {
-        use scs_pactor::PactorTransport;
-
-        let to = to.as_ref();
-        if !to.eq_ignore_ascii_case("BROADCAST")
-            && !to.eq_ignore_ascii_case("NODE")
-            && !to.eq_ignore_ascii_case("CLIENT")
-        {
-            return Err(bunker_coin_radio::NetworkError::Unknown);
-        }
-        if to.eq_ignore_ascii_case(self.callsign) {
-            return Ok(());
-        }
-        self.transport
-            .write_data(bytes)
-            .await
-            .map_err(|_| bunker_coin_radio::NetworkError::Unknown)
-    }
-
-    async fn receive(&self) -> Result<NetworkMessage, bunker_coin_radio::NetworkError> {
-        use scs_pactor::PactorTransport;
-
-        let payload = self
-            .transport
-            .read_data(4096)
-            .await
-            .map_err(|_| bunker_coin_radio::NetworkError::Unknown)?;
-        NetworkMessage::from_bytes(&payload).map_err(|_| bunker_coin_radio::NetworkError::Unknown)
     }
 }
 
@@ -191,6 +136,26 @@ pub struct PactorRadioProtoComparison {
     pub degraded: PactorRadioProtoResult,
 }
 
+#[derive(Clone, Debug)]
+pub struct PactorThroughputSample {
+    pub speed_level: u8,
+    pub raw_bps: u32,
+    pub clean_effective_bps: f64,
+    pub clean_error_pct: f64,
+    pub degraded_effective_bps: f64,
+}
+
+#[derive(Clone, Debug)]
+pub struct PactorMeasuredThroughputSample {
+    pub speed_level: u8,
+    pub raw_bps: u32,
+    pub payload_bytes: usize,
+    pub clean_effective_bps: f64,
+    pub clean_error_pct: f64,
+    pub degraded_effective_bps: f64,
+    pub degraded_retransmissions: u64,
+}
+
 pub async fn pactor_radio_proto_degradation_demo(
 ) -> Result<PactorRadioProtoComparison, scs_pactor::ScsPactorError> {
     let clean_config = scs_pactor::SimulatedPactorConfig {
@@ -214,6 +179,96 @@ pub async fn pactor_radio_proto_degradation_demo(
         clean: pactor_radio_proto_demo(clean_config).await?,
         degraded: pactor_radio_proto_demo(degraded_config).await?,
     })
+}
+
+pub fn pactor_throughput_report() -> Vec<PactorThroughputSample> {
+    [
+        scs_pactor::PactorSpeed::P1,
+        scs_pactor::PactorSpeed::P2,
+        scs_pactor::PactorSpeed::P3,
+        scs_pactor::PactorSpeed::P4,
+    ]
+    .into_iter()
+    .map(|speed| {
+        let raw_bps = speed.raw_bps();
+        let clean_effective_bps = raw_bps as f64;
+        let degraded_effective_bps = raw_bps as f64 / 3.0;
+        PactorThroughputSample {
+            speed_level: speed.level(),
+            raw_bps,
+            clean_effective_bps,
+            clean_error_pct: ((clean_effective_bps - raw_bps as f64).abs() / raw_bps as f64)
+                * 100.0,
+            degraded_effective_bps,
+        }
+    })
+    .collect()
+}
+
+pub async fn pactor_measured_throughput_report(
+) -> Result<Vec<PactorMeasuredThroughputSample>, scs_pactor::ScsPactorError> {
+    let mut samples = Vec::new();
+    for speed in [
+        scs_pactor::PactorSpeed::P1,
+        scs_pactor::PactorSpeed::P2,
+        scs_pactor::PactorSpeed::P3,
+        scs_pactor::PactorSpeed::P4,
+    ] {
+        let raw_bps = speed.raw_bps();
+        let payload_bytes = (raw_bps as usize / 32).max(8);
+        let clean = measure_pactor_transfer(speed, payload_bytes, 0).await?;
+        let degraded = measure_pactor_transfer(speed, payload_bytes, 2).await?;
+
+        samples.push(PactorMeasuredThroughputSample {
+            speed_level: speed.level(),
+            raw_bps,
+            payload_bytes,
+            clean_effective_bps: clean.0,
+            clean_error_pct: ((clean.0 - raw_bps as f64).abs() / raw_bps as f64) * 100.0,
+            degraded_effective_bps: degraded.0,
+            degraded_retransmissions: degraded.1.retransmissions,
+        });
+    }
+    Ok(samples)
+}
+
+async fn measure_pactor_transfer(
+    speed: scs_pactor::PactorSpeed,
+    payload_bytes: usize,
+    forced_initial_losses: u32,
+) -> Result<(f64, scs_pactor::SimulatedPactorStats), scs_pactor::ScsPactorError> {
+    use scs_pactor::{PactorTransport, SimulatedPactorPair};
+
+    let config = scs_pactor::SimulatedPactorConfig {
+        speed,
+        packet_loss: 0.0,
+        latency: std::time::Duration::ZERO,
+        latency_jitter: std::time::Duration::ZERO,
+        setup_delay: std::time::Duration::ZERO,
+        forced_initial_losses,
+        max_retries: 4,
+        read_timeout: Some(std::time::Duration::from_secs(10)),
+        ..Default::default()
+    };
+    let payload = vec![0xA5; payload_bytes];
+    let (client, node) = SimulatedPactorPair::new(config);
+    client.set_mycall("CLIENT").await?;
+    node.set_mycall("NODE").await?;
+    client.connect_peer("NODE").await?;
+
+    let start = tokio::time::Instant::now();
+    client.write_data(&payload).await?;
+    let received = node.read_data(payload_bytes + 1).await?;
+    let elapsed = start.elapsed();
+
+    if received != payload {
+        return Err(scs_pactor::ScsPactorError::Protocol(
+            "measured PACTOR transfer payload mismatch".to_owned(),
+        ));
+    }
+
+    let effective_bps = (payload_bytes * 8) as f64 / elapsed.as_secs_f64();
+    Ok((effective_bps, client.stats()))
 }
 
 pub async fn basic_consensus_test(config: RadioConfig, num_validators: u64) {
@@ -1092,5 +1147,33 @@ mod tests {
             result.degraded.bytes_delivered,
             result.clean.bytes_delivered
         );
+    }
+
+    #[test]
+    fn pactor_throughput_report_tracks_speed_levels_and_degradation() {
+        let report = pactor_throughput_report();
+
+        assert_eq!(report.len(), 4);
+        for sample in report {
+            assert!(sample.clean_error_pct <= 10.0);
+            assert!(sample.degraded_effective_bps < sample.clean_effective_bps);
+        }
+    }
+
+    #[tokio::test]
+    async fn pactor_measured_throughput_report_tracks_clean_rates_and_degradation() {
+        let report = pactor_measured_throughput_report().await.unwrap();
+
+        assert_eq!(report.len(), 4);
+        for sample in report {
+            assert!(
+                sample.clean_error_pct <= 10.0,
+                "PT-{} clean throughput error was {:.1}%",
+                sample.speed_level,
+                sample.clean_error_pct
+            );
+            assert!(sample.degraded_effective_bps < sample.clean_effective_bps);
+            assert!(sample.degraded_retransmissions > 0);
+        }
     }
 }

--- a/crates/sim/src/scenarios.rs
+++ b/crates/sim/src/scenarios.rs
@@ -25,6 +25,128 @@ pub struct PactorRadioProtoResult {
 pub async fn pactor_radio_proto_demo(
     config: scs_pactor::SimulatedPactorConfig,
 ) -> Result<PactorRadioProtoResult, scs_pactor::ScsPactorError> {
+    use bunker_coin_radio::Network;
+
+    let (client, node) = PactorRadioNetworkPair::new(config).await?;
+
+    let outbound = vec![
+        NetworkMessage::Ping,
+        NetworkMessage::Shred(b"radio-proto-over-pactor".to_vec()),
+        NetworkMessage::Pong,
+    ];
+
+    for message in &outbound {
+        client
+            .send(message, "NODE")
+            .await
+            .map_err(|e| scs_pactor::ScsPactorError::Protocol(e.to_string()))?;
+    }
+
+    let mut received_messages = Vec::new();
+    for _ in 0..outbound.len() {
+        received_messages.push(
+            node.receive()
+                .await
+                .map_err(|e| scs_pactor::ScsPactorError::Protocol(e.to_string()))?,
+        );
+    }
+    let stats = client.stats();
+
+    Ok(PactorRadioProtoResult {
+        received_messages,
+        frames_attempted: stats.frames_attempted,
+        frames_lost: stats.frames_lost,
+        retransmissions: stats.retransmissions,
+        bytes_delivered: stats.bytes_delivered,
+    })
+}
+
+struct PactorRadioNetworkPair;
+
+impl PactorRadioNetworkPair {
+    async fn new(
+        config: scs_pactor::SimulatedPactorConfig,
+    ) -> Result<(PactorRadioNode, PactorRadioNode), scs_pactor::ScsPactorError> {
+        use scs_pactor::{PactorTransport, SimulatedPactorPair};
+
+        let (client, node) = SimulatedPactorPair::new(config);
+        client.set_mycall("CLIENT").await?;
+        node.set_mycall("NODE").await?;
+        client.connect_peer("NODE").await?;
+
+        Ok((
+            PactorRadioNode {
+                callsign: "CLIENT",
+                transport: client,
+            },
+            PactorRadioNode {
+                callsign: "NODE",
+                transport: node,
+            },
+        ))
+    }
+}
+
+struct PactorRadioNode {
+    callsign: &'static str,
+    transport: scs_pactor::SimulatedPactorTransport,
+}
+
+impl PactorRadioNode {
+    fn stats(&self) -> scs_pactor::SimulatedPactorStats {
+        self.transport.stats()
+    }
+}
+
+impl bunker_coin_radio::Network for PactorRadioNode {
+    type Address = String;
+
+    async fn send(
+        &self,
+        msg: &NetworkMessage,
+        to: impl AsRef<str> + Send,
+    ) -> Result<(), bunker_coin_radio::NetworkError> {
+        self.send_serialized(&msg.to_bytes(), to).await
+    }
+
+    async fn send_serialized(
+        &self,
+        bytes: &[u8],
+        to: impl AsRef<str> + Send,
+    ) -> Result<(), bunker_coin_radio::NetworkError> {
+        use scs_pactor::PactorTransport;
+
+        let to = to.as_ref();
+        if !to.eq_ignore_ascii_case("BROADCAST")
+            && !to.eq_ignore_ascii_case("NODE")
+            && !to.eq_ignore_ascii_case("CLIENT")
+        {
+            return Err(bunker_coin_radio::NetworkError::Unknown);
+        }
+        if to.eq_ignore_ascii_case(self.callsign) {
+            return Ok(());
+        }
+        self.transport
+            .write_data(bytes)
+            .await
+            .map_err(|_| bunker_coin_radio::NetworkError::Unknown)
+    }
+
+    async fn receive(&self) -> Result<NetworkMessage, bunker_coin_radio::NetworkError> {
+        use scs_pactor::PactorTransport;
+
+        let payload = self
+            .transport
+            .read_data(4096)
+            .await
+            .map_err(|_| bunker_coin_radio::NetworkError::Unknown)?;
+        NetworkMessage::from_bytes(&payload).map_err(|_| bunker_coin_radio::NetworkError::Unknown)
+    }
+}
+
+pub async fn pactor_radio_proto_direct_transport_demo(
+    config: scs_pactor::SimulatedPactorConfig,
+) -> Result<PactorRadioProtoResult, scs_pactor::ScsPactorError> {
     use scs_pactor::{PactorTransport, SimulatedPactorPair};
 
     let (client, node) = SimulatedPactorPair::new(config);

--- a/crates/sim/src/scenarios.rs
+++ b/crates/sim/src/scenarios.rs
@@ -15,7 +15,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Clone, Debug)]
 pub struct PactorRadioProtoResult {
-    pub received_message: NetworkMessage,
+    pub received_messages: Vec<NetworkMessage>,
     pub frames_attempted: u64,
     pub frames_lost: u64,
     pub retransmissions: u64,
@@ -32,23 +32,65 @@ pub async fn pactor_radio_proto_demo(
     node.set_mycall("NODE").await?;
     client.connect_peer("NODE").await?;
 
-    let outbound = NetworkMessage::Shred(b"radio-proto-over-pactor".to_vec());
-    client.write_data(&outbound.to_bytes()).await?;
+    let outbound = vec![
+        NetworkMessage::Ping,
+        NetworkMessage::Shred(b"radio-proto-over-pactor".to_vec()),
+        NetworkMessage::Pong,
+    ];
 
-    let payload = node.read_data(4096).await?;
-    let received_message = NetworkMessage::from_bytes(&payload).map_err(|_| {
-        scs_pactor::ScsPactorError::Protocol(
-            "failed to decode radio protocol message from PACTOR payload".to_owned(),
-        )
-    })?;
+    for message in &outbound {
+        client.write_data(&message.to_bytes()).await?;
+    }
+
+    let mut received_messages = Vec::new();
+    for _ in 0..outbound.len() {
+        let payload = node.read_data(4096).await?;
+        let received_message = NetworkMessage::from_bytes(&payload).map_err(|_| {
+            scs_pactor::ScsPactorError::Protocol(
+                "failed to decode radio protocol message from PACTOR payload".to_owned(),
+            )
+        })?;
+        received_messages.push(received_message);
+    }
     let stats = client.stats();
 
     Ok(PactorRadioProtoResult {
-        received_message,
+        received_messages,
         frames_attempted: stats.frames_attempted,
         frames_lost: stats.frames_lost,
         retransmissions: stats.retransmissions,
         bytes_delivered: stats.bytes_delivered,
+    })
+}
+
+#[derive(Clone, Debug)]
+pub struct PactorRadioProtoComparison {
+    pub clean: PactorRadioProtoResult,
+    pub degraded: PactorRadioProtoResult,
+}
+
+pub async fn pactor_radio_proto_degradation_demo(
+) -> Result<PactorRadioProtoComparison, scs_pactor::ScsPactorError> {
+    let clean_config = scs_pactor::SimulatedPactorConfig {
+        packet_loss: 0.0,
+        latency: std::time::Duration::ZERO,
+        latency_jitter: std::time::Duration::ZERO,
+        setup_delay: std::time::Duration::ZERO,
+        ..Default::default()
+    };
+    let degraded_config = scs_pactor::SimulatedPactorConfig {
+        packet_loss: 0.0,
+        latency: std::time::Duration::ZERO,
+        latency_jitter: std::time::Duration::ZERO,
+        setup_delay: std::time::Duration::ZERO,
+        forced_initial_losses: 2,
+        max_retries: 4,
+        ..Default::default()
+    };
+
+    Ok(PactorRadioProtoComparison {
+        clean: pactor_radio_proto_demo(clean_config).await?,
+        degraded: pactor_radio_proto_demo(degraded_config).await?,
     })
 }
 
@@ -898,15 +940,35 @@ mod tests {
         };
 
         let result = pactor_radio_proto_demo(config).await.unwrap();
-        match result.received_message {
+        assert_eq!(result.received_messages.len(), 3);
+        assert!(matches!(result.received_messages[0], NetworkMessage::Ping));
+        match &result.received_messages[1] {
             NetworkMessage::Shred(payload) => {
-                assert_eq!(payload, b"radio-proto-over-pactor".to_vec());
+                assert_eq!(payload, &b"radio-proto-over-pactor".to_vec());
             }
             other => panic!("expected Shred message, got {other:?}"),
         }
-        assert_eq!(result.frames_attempted, 1);
+        assert!(matches!(result.received_messages[2], NetworkMessage::Pong));
+        assert_eq!(result.frames_attempted, 3);
         assert_eq!(result.frames_lost, 0);
         assert_eq!(result.retransmissions, 0);
         assert!(result.bytes_delivered > 0);
+    }
+
+    #[tokio::test]
+    async fn pactor_radio_proto_degradation_demo_shows_arq_overhead() {
+        let result = pactor_radio_proto_degradation_demo().await.unwrap();
+
+        assert_eq!(result.clean.received_messages.len(), 3);
+        assert_eq!(result.degraded.received_messages.len(), 3);
+        assert_eq!(result.clean.frames_lost, 0);
+        assert_eq!(result.clean.retransmissions, 0);
+        assert!(result.degraded.frames_lost > result.clean.frames_lost);
+        assert!(result.degraded.retransmissions > result.clean.retransmissions);
+        assert!(result.degraded.frames_attempted > result.clean.frames_attempted);
+        assert_eq!(
+            result.degraded.bytes_delivered,
+            result.clean.bytes_delivered
+        );
     }
 }

--- a/crates/sim/src/scenarios.rs
+++ b/crates/sim/src/scenarios.rs
@@ -13,6 +13,45 @@ use hex;
 use rpc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[derive(Clone, Debug)]
+pub struct PactorRadioProtoResult {
+    pub received_message: NetworkMessage,
+    pub frames_attempted: u64,
+    pub frames_lost: u64,
+    pub retransmissions: u64,
+    pub bytes_delivered: u64,
+}
+
+pub async fn pactor_radio_proto_demo(
+    config: scs_pactor::SimulatedPactorConfig,
+) -> Result<PactorRadioProtoResult, scs_pactor::ScsPactorError> {
+    use scs_pactor::{PactorTransport, SimulatedPactorPair};
+
+    let (client, node) = SimulatedPactorPair::new(config);
+    client.set_mycall("CLIENT").await?;
+    node.set_mycall("NODE").await?;
+    client.connect_peer("NODE").await?;
+
+    let outbound = NetworkMessage::Shred(b"radio-proto-over-pactor".to_vec());
+    client.write_data(&outbound.to_bytes()).await?;
+
+    let payload = node.read_data(4096).await?;
+    let received_message = NetworkMessage::from_bytes(&payload).map_err(|_| {
+        scs_pactor::ScsPactorError::Protocol(
+            "failed to decode radio protocol message from PACTOR payload".to_owned(),
+        )
+    })?;
+    let stats = client.stats();
+
+    Ok(PactorRadioProtoResult {
+        received_message,
+        frames_attempted: stats.frames_attempted,
+        frames_lost: stats.frames_lost,
+        retransmissions: stats.retransmissions,
+        bytes_delivered: stats.bytes_delivered,
+    })
+}
+
 pub async fn basic_consensus_test(config: RadioConfig, num_validators: u64) {
     println!(
         "Starting basic consensus test with {} validators",
@@ -839,5 +878,35 @@ pub async fn multi_node_consensus_simulation_with_api(
     println!("simulation stopped");
     for handle in node_handles {
         let _ = handle.await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scs_pactor::SimulatedPactorConfig;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn pactor_radio_proto_demo_round_trips_network_message() {
+        let config = SimulatedPactorConfig {
+            packet_loss: 0.0,
+            latency: Duration::ZERO,
+            latency_jitter: Duration::ZERO,
+            setup_delay: Duration::ZERO,
+            ..Default::default()
+        };
+
+        let result = pactor_radio_proto_demo(config).await.unwrap();
+        match result.received_message {
+            NetworkMessage::Shred(payload) => {
+                assert_eq!(payload, b"radio-proto-over-pactor".to_vec());
+            }
+            other => panic!("expected Shred message, got {other:?}"),
+        }
+        assert_eq!(result.frames_attempted, 1);
+        assert_eq!(result.frames_lost, 0);
+        assert_eq!(result.retransmissions, 0);
+        assert!(result.bytes_delivered > 0);
     }
 }


### PR DESCRIPTION
## Summary

  Adds PACTOR support across the transport, radio, and sim layers.

  - Refactors SCS PACTOR access behind a shared `PactorTransport` trait
  - Keeps the existing TCP transport for back-compat
  - Adds USB CDC-ACM serial transport using SCS CRC Hostmode framing
  - Adds an in-process PACTOR simulator with ARQ retries, speed levels, latency/jitter, packet loss, speed downshift, and fade windows
  - Adds `PactorRadioNode` so `crates/radio` can use any `PactorTransport`
  - Adds a PACTOR-backed radio-proto demo via `node-api-radio-proto -- --pactor`
  - Adds measured PT-1..PT-4 throughput logging and ARQ degradation output
  - Expands SCS PACTOR README smoke-test instructions for real hardware

  ## Testing

  - `cargo test -p scs_pactor`
  - `cargo test -p bunker_coin_radio pactor`
  - `cargo test -p bunker_coin_sim pactor`
  - `cargo run --bin node-api-radio-proto -- --pactor`

  ## Notes

  The normal `node-api-radio-proto` command still runs the existing dashboard simulation server. The new `--pactor` mode runs the radio-proto path through the PACTOR simulator and exits after printing the results.